### PR TITLE
Fix Rust orbital rotation numerical instability

### DIFF
--- a/python/ffsim/gates/orbital_rotation.py
+++ b/python/ffsim/gates/orbital_rotation.py
@@ -21,14 +21,9 @@ from pyscf.fci import cistring
 from scipy.special import comb
 
 from ffsim._lib import (
-    # apply_givens_rotation_in_place,
+    apply_givens_rotation_in_place,
     apply_phase_shift_in_place,
     apply_single_column_transformation_in_place,
-)
-
-# TODO delete this and uncomment import from ffsim._lib after fixing bug
-from ffsim._slow.gates.orbital_rotation import (
-    apply_givens_rotation_in_place_slow as apply_givens_rotation_in_place,
 )
 from ffsim.cistring import gen_orbital_rotation_index
 from ffsim.linalg import givens_decomposition, lup

--- a/src/gates/orbital_rotation.rs
+++ b/src/gates/orbital_rotation.rs
@@ -160,7 +160,8 @@ pub fn apply_givens_rotation_in_place(
     let shape = vec.shape();
     let dim_b = shape[1] as i32;
     let s_abs = s.norm();
-    let phase = s / s_abs;
+    let angle = s.arg();
+    let phase = Complex64::new(angle.cos(), angle.sin());
     let phase_conj = phase.conj();
 
     // TODO parallelize this


### PR DESCRIPTION
Use `arg` to compute complex angle instead of dividing by norm, which was causing a NaNs due to division by zero.

Fixes #95 