### PR TITLE
rename t2_amplitudes and t1_amplitudes to t2 and t1

### DIFF
--- a/python/ffsim/variational/ucj.py
+++ b/python/ffsim/variational/ucj.py
@@ -179,20 +179,18 @@ class UCJOperator:
 
     @staticmethod
     def from_t_amplitudes(
-        t2_amplitudes: np.ndarray,
+        t2: np.ndarray,
         *,
-        t1_amplitudes: np.ndarray | None = None,
+        t1: np.ndarray | None = None,
         n_reps: int | None = None,
         tol: float = 1e-8,
     ) -> UCJOperator:
         """Initialize the UCJ operator from t2 (and optionally t1) amplitudes."""
         # TODO maybe allow specifying alpha-alpha and alpha-beta indices
-        nocc, _, nvrt, _ = t2_amplitudes.shape
+        nocc, _, nvrt, _ = t2.shape
         norb = nocc + nvrt
 
-        diag_coulomb_mats, orbital_rotations = double_factorized_t2(
-            t2_amplitudes, tol=tol
-        )
+        diag_coulomb_mats, orbital_rotations = double_factorized_t2(t2, tol=tol)
         n_vecs, norb, _ = diag_coulomb_mats.shape
         expanded_diag_coulomb_mats = np.zeros((2 * n_vecs, norb, norb))
         expanded_orbital_rotations = np.zeros((2 * n_vecs, norb, norb), dtype=complex)
@@ -202,10 +200,10 @@ class UCJOperator:
         expanded_orbital_rotations[1::2] = orbital_rotations.conj()
 
         final_orbital_rotation = None
-        if t1_amplitudes is not None:
+        if t1 is not None:
             final_orbital_rotation_generator = np.zeros((norb, norb), dtype=complex)
-            final_orbital_rotation_generator[:nocc, nocc:] = t1_amplitudes
-            final_orbital_rotation_generator[nocc:, :nocc] = -t1_amplitudes.T
+            final_orbital_rotation_generator[:nocc, nocc:] = t1
+            final_orbital_rotation_generator[nocc:, :nocc] = -t1.T
             final_orbital_rotation = scipy.linalg.expm(final_orbital_rotation_generator)
 
         return UCJOperator(
@@ -424,27 +422,25 @@ class RealUCJOperator:
 
     @staticmethod
     def from_t_amplitudes(
-        t2_amplitudes: np.ndarray,
+        t2: np.ndarray,
         *,
-        t1_amplitudes: np.ndarray | None = None,
+        t1: np.ndarray | None = None,
         n_reps: int | None = None,
         tol: float = 1e-8,
     ) -> "RealUCJOperator":
         """Initialize the real UCJ operator from t2 (and optionally t1) amplitudes."""
         # TODO maybe allow specifying alpha-alpha and alpha-beta indices
-        nocc, _, nvrt, _ = t2_amplitudes.shape
+        nocc, _, nvrt, _ = t2.shape
         norb = nocc + nvrt
 
-        diag_coulomb_mats, orbital_rotations = double_factorized_t2(
-            t2_amplitudes, tol=tol
-        )
+        diag_coulomb_mats, orbital_rotations = double_factorized_t2(t2, tol=tol)
         _, norb, _ = diag_coulomb_mats.shape
 
         final_orbital_rotation = None
-        if t1_amplitudes is not None:
+        if t1 is not None:
             final_orbital_rotation_generator = np.zeros((norb, norb), dtype=complex)
-            final_orbital_rotation_generator[:nocc, nocc:] = t1_amplitudes
-            final_orbital_rotation_generator[nocc:, :nocc] = -t1_amplitudes.T
+            final_orbital_rotation_generator[:nocc, nocc:] = t1
+            final_orbital_rotation_generator[nocc:, :nocc] = -t1.T
             final_orbital_rotation = scipy.linalg.expm(final_orbital_rotation_generator)
 
         return RealUCJOperator(

--- a/tests/variational/ucj_test.py
+++ b/tests/variational/ucj_test.py
@@ -126,7 +126,7 @@ def test_t_amplitudes_roundtrip():
     t2 = ffsim.random.random_t2_amplitudes(norb, nocc, dtype=float)
     t1 = rng.standard_normal((nocc, norb - nocc))
 
-    operator = ffsim.UCJOperator.from_t_amplitudes(t2, t1_amplitudes=t1)
+    operator = ffsim.UCJOperator.from_t_amplitudes(t2, t1=t1)
     t2_roundtripped, t1_roundtripped = operator.to_t_amplitudes(nocc=nocc)
 
     np.testing.assert_allclose(t2_roundtripped, t2, atol=1e-12)
@@ -325,7 +325,7 @@ def test_real_ucj_t_amplitudes_roundtrip():
     t2 = ffsim.random.random_t2_amplitudes(norb, nocc, dtype=float)
     t1 = rng.standard_normal((nocc, norb - nocc))
 
-    operator = ffsim.RealUCJOperator.from_t_amplitudes(t2, t1_amplitudes=t1)
+    operator = ffsim.RealUCJOperator.from_t_amplitudes(t2, t1=t1)
     t2_roundtripped, t1_roundtripped = operator.to_t_amplitudes(nocc=nocc)
 
     np.testing.assert_allclose(t2_roundtripped, t2, atol=1e-12)


### PR DESCRIPTION
For consistency with `MolecularData` and pyscf.