### PR TITLE
Remove tox as dev dependency since it should be installed in an isolated environment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ dev = [
     "ruff == 0.3.4",
     "sphinx",
     "sphinx-autodoc-typehints",
-    "tox",
 ]
 
 [tool.maturin]


### PR DESCRIPTION
It's recommended that tox be installed in an isolated environment, see e.g. https://tox.wiki/en/4.14.2/installation.html