### PR TITLE
Change SlaterDeterminantJW API to match slater_determinant function

### DIFF
--- a/tests/python/qiskit/slater_determinant_test.py
+++ b/tests/python/qiskit/slater_determinant_test.py
@@ -19,31 +19,41 @@ from qiskit.quantum_info import Statevector
 import ffsim
 
 
-@pytest.mark.parametrize("norb, spin", ffsim.testing.generate_norb_spin(range(5)))
-def test_random_orbital_coeffs(norb: int, spin: ffsim.Spin):
-    """Test circuit with crandom orbital coefficients gives correct output state."""
+@pytest.mark.parametrize("norb, nelec", ffsim.testing.generate_norb_nelec(range(5)))
+def test_random_slater_determinant(norb: int, nelec: tuple[int, int]):
+    """Test random Slater determinant circuit gives correct output state."""
     rng = np.random.default_rng()
-    nocc = norb // 2
-    nelec = (
-        nocc if spin & ffsim.Spin.ALPHA else 0,
-        nocc if spin & ffsim.Spin.BETA else 0,
-    )
     for _ in range(3):
+        occupied_orbitals = ffsim.testing.random_occupied_orbitals(norb, nelec)
         orbital_rotation = ffsim.random.random_unitary(norb, seed=rng)
-        orbital_coeffs = orbital_rotation[:, :nocc]
-        gate = ffsim.qiskit.PrepareSlaterDeterminantJW(orbital_coeffs, spin=spin)
+        gate = ffsim.qiskit.PrepareSlaterDeterminantJW(
+            norb, occupied_orbitals, orbital_rotation=orbital_rotation
+        )
 
         statevec = Statevector.from_int(0, 2 ** (2 * norb)).evolve(gate)
         result = ffsim.qiskit.qiskit_vec_to_ffsim_vec(
             np.array(statevec), norb=norb, nelec=nelec
         )
 
-        occupied_orbitals = (
-            range(nocc) if spin & ffsim.Spin.ALPHA else [],
-            range(nocc) if spin & ffsim.Spin.BETA else [],
-        )
         expected = ffsim.slater_determinant(
             norb, occupied_orbitals, orbital_rotation=orbital_rotation
         )
 
         ffsim.testing.assert_allclose_up_to_global_phase(result, expected)
+
+
+@pytest.mark.parametrize("norb, nelec", ffsim.testing.generate_norb_nelec(range(5)))
+def test_slater_determinant_no_rotation(norb: int, nelec: tuple[int, int]):
+    """Test Slater determinant circuit with no orbital rotation."""
+    occupied_orbitals = ffsim.testing.random_occupied_orbitals(norb, nelec)
+
+    gate = ffsim.qiskit.PrepareSlaterDeterminantJW(norb, occupied_orbitals)
+
+    statevec = Statevector.from_int(0, 2 ** (2 * norb)).evolve(gate)
+    result = ffsim.qiskit.qiskit_vec_to_ffsim_vec(
+        np.array(statevec), norb=norb, nelec=nelec
+    )
+
+    expected = ffsim.slater_determinant(norb, occupied_orbitals)
+
+    ffsim.testing.assert_allclose_up_to_global_phase(result, expected)


### PR DESCRIPTION
Changes the API of SlaterDeterminantJW to match the slater_determinant function. In particular, it accepts occupied orbitals and a full orbital rotation matrix, instead of just a subset of the orbital rotation matrix containing the columns for the desired orbitals.