### PR TITLE
remove input validation for low-level gates

### DIFF
--- a/python/ffsim/gates/basic_gates.py
+++ b/python/ffsim/gates/basic_gates.py
@@ -109,12 +109,7 @@ def apply_givens_rotation(
     mat = np.eye(norb)
     mat[np.ix_(target_orbs, target_orbs)] = [[c, s], [-s, c]]
     return apply_orbital_rotation(
-        vec,
-        pair_for_spin(mat, spin=spin),
-        norb=norb,
-        nelec=nelec,
-        copy=copy,
-        validate=False,
+        vec, pair_for_spin(mat, spin=spin), norb=norb, nelec=nelec, copy=copy
     )
 
 

--- a/python/ffsim/gates/diag_coulomb.py
+++ b/python/ffsim/gates/diag_coulomb.py
@@ -16,7 +16,6 @@ import math
 
 import numpy as np
 
-from ffsim import linalg
 from ffsim._lib import (
     apply_diag_coulomb_evolution_in_place_num_rep,
     apply_diag_coulomb_evolution_in_place_z_rep,
@@ -50,9 +49,6 @@ def apply_diag_coulomb_evolution(
     | None = None,
     z_representation: bool = False,
     copy: bool = True,
-    validate: bool = True,
-    rtol: float = 1e-5,
-    atol: float = 1e-8,
 ) -> np.ndarray:
     r"""Apply time evolution by a (rotated) diagonal Coulomb operator.
 
@@ -97,20 +93,10 @@ def apply_diag_coulomb_evolution(
               vector, but the original vector may have its data overwritten.
               It is also possible that the original vector is returned,
               modified in-place.
-        validate: Whether to check that the input matrix is real symmetric and raise an
-            error if it isn't.
-        rtol: Relative numerical tolerance for input validation.
-        atol: Absolute numerical tolerance for input validation.
 
     Returns:
         The evolved state vector.
-
-    Raises:
-        ValueError: The input matrix was not real symmetric.
     """
-    if validate:
-        _validate_diag_coulomb_mat(mat, rtol=rtol, atol=atol)
-
     if copy:
         vec = vec.copy()
 
@@ -170,36 +156,6 @@ def apply_diag_coulomb_evolution(
         )
 
     return vec
-
-
-def _validate_diag_coulomb_mat(
-    mat: np.ndarray | tuple[np.ndarray | None, np.ndarray | None, np.ndarray | None],
-    rtol: float,
-    atol: float,
-) -> None:
-    if isinstance(mat, np.ndarray):
-        if not linalg.is_real_symmetric(mat, rtol=rtol, atol=atol):
-            raise ValueError("The input matrix was not real symmetric.")
-    else:
-        mat_aa, mat_ab, mat_bb = mat
-        if mat_aa is not None and not linalg.is_real_symmetric(
-            mat_aa, rtol=rtol, atol=atol
-        ):
-            raise ValueError(
-                "The input matrix for alpha-alpha interactions was not real symmetric."
-            )
-        if mat_ab is not None and not linalg.is_real_symmetric(
-            mat_ab, rtol=rtol, atol=atol
-        ):
-            raise ValueError(
-                "The input matrix for alpha-beta interactions was not real symmetric."
-            )
-        if mat_bb is not None and not linalg.is_real_symmetric(
-            mat_bb, rtol=rtol, atol=atol
-        ):
-            raise ValueError(
-                "The input matrix for beta-beta interactions was not real symmetric."
-            )
 
 
 def _get_mat_exp(

--- a/python/ffsim/gates/num_op_sum.py
+++ b/python/ffsim/gates/num_op_sum.py
@@ -90,12 +90,7 @@ def apply_num_op_sum_evolution(
 
     Returns:
         The evolved state vector.
-
-    Raises:
-        ValueError: ``coeffs`` must be a one-dimensional vector with length ``norb``.
     """
-    _validate_coeffs(coeffs, norb)
-
     if copy:
         vec = vec.copy()
 
@@ -136,31 +131,6 @@ def apply_num_op_sum_evolution(
         )
 
     return vec
-
-
-def _validate_coeffs(
-    coeffs: np.ndarray | tuple[np.ndarray | None, np.ndarray | None], norb: int
-) -> None:
-    if isinstance(coeffs, np.ndarray):
-        if coeffs.shape != (norb,):
-            raise ValueError(
-                "coeffs must be a one-dimensional vector with length norb. "
-                f"Got norb = {norb} but coeffs had shape {coeffs.shape}"
-            )
-    else:
-        coeffs_a, coeffs_b = coeffs
-        if coeffs_a is not None and coeffs_a.shape != (norb,):
-            raise ValueError(
-                "coeffs must be a one-dimensional vector with length norb. "
-                f"Got norb = {norb} but coeffs for spin alpha had shape "
-                f"{coeffs_a.shape}"
-            )
-        if coeffs_b is not None and coeffs_b.shape != (norb,):
-            raise ValueError(
-                "coeffs must be a one-dimensional vector with length norb. "
-                f"Got norb = {norb} but coeffs for spin beta had shape "
-                f"{coeffs_b.shape}"
-            )
 
 
 def _get_phases(

--- a/python/ffsim/gates/orbital_rotation.py
+++ b/python/ffsim/gates/orbital_rotation.py
@@ -18,7 +18,6 @@ from functools import lru_cache
 import numpy as np
 from pyscf.fci import cistring
 
-from ffsim import linalg
 from ffsim._lib import (
     apply_givens_rotation_in_place,
     apply_phase_shift_in_place,
@@ -33,9 +32,6 @@ def apply_orbital_rotation(
     nelec: tuple[int, int],
     *,
     copy: bool = True,
-    validate: bool = True,
-    rtol: float = 1e-5,
-    atol: float = 1e-8,
 ) -> np.ndarray:
     r"""Apply an orbital rotation to a vector.
 
@@ -62,8 +58,8 @@ def apply_orbital_rotation(
             to apply to both spin sectors, or you can pass a pair of Numpy arrays
             specifying independent orbital rotations for spin alpha and spin beta.
             If passing a pair, you can use ``None`` for one of the
-            values in the pair to indicate that no operation should be applied to that
-            spin sector.
+            values in the pair to indicate that no operation should be applied to
+            that spin sector.
         norb: The number of spatial orbitals.
         nelec: The number of alpha and beta electrons.
         copy: Whether to copy the vector before operating on it.
@@ -74,20 +70,10 @@ def apply_orbital_rotation(
               vector, but the original vector may have its data overwritten.
               It is also possible that the original vector is returned,
               modified in-place.
-        validate: Whether to check that the input matrix is unitary and raise an error
-            if it isn't.
-        rtol: Relative numerical tolerance for input validation.
-        atol: Absolute numerical tolerance for input validation.
 
     Returns:
         The transformed vector.
-
-    Raises:
-        ValueError: The input matrix was not unitary.
     """
-    if validate:
-        _validate_orbital_rotation(mat, rtol=rtol, atol=atol)
-
     if copy:
         vec = vec.copy()
 
@@ -124,26 +110,6 @@ def apply_orbital_rotation(
         vec = vec.T.copy()
 
     return vec.reshape(-1)
-
-
-def _validate_orbital_rotation(
-    mat: np.ndarray | tuple[np.ndarray | None, np.ndarray | None],
-    rtol: float,
-    atol: float,
-) -> None:
-    if isinstance(mat, np.ndarray):
-        if not linalg.is_unitary(mat, rtol=rtol, atol=atol):
-            raise ValueError("The input orbital rotation matrix was not unitary.")
-    else:
-        mat_a, mat_b = mat
-        if mat_a is not None and not linalg.is_unitary(mat_a, rtol=rtol, atol=atol):
-            raise ValueError(
-                "The input orbital rotation matrix for spin alpha was not unitary."
-            )
-        if mat_b is not None and not linalg.is_unitary(mat_b, rtol=rtol, atol=atol):
-            raise ValueError(
-                "The input orbital rotation matrix for spin beta was not unitary."
-            )
 
 
 def _get_givens_decomposition(

--- a/python/ffsim/qiskit/sim.py
+++ b/python/ffsim/qiskit/sim.py
@@ -180,7 +180,6 @@ def _evolve_statevector(
             norb=norb,
             nelec=nelec,
             copy=False,
-            validate=False,
         )
         vec = gates.apply_orbital_rotation(
             vec,
@@ -188,7 +187,6 @@ def _evolve_statevector(
             norb=norb,
             nelec=nelec,
             copy=False,
-            validate=False,
         )
         return Statevector(vec=vec, norb=norb, nelec=nelec)
 
@@ -199,7 +197,7 @@ def _evolve_statevector(
                 "consecutive qubits, in ascending order."
             )
         vec = gates.apply_orbital_rotation(
-            vec, op.orbital_rotation, norb=norb, nelec=nelec, copy=False, validate=False
+            vec, op.orbital_rotation, norb=norb, nelec=nelec, copy=False
         )
         return Statevector(vec=vec, norb=norb, nelec=nelec)
 

--- a/python/ffsim/variational/givens.py
+++ b/python/ffsim/variational/givens.py
@@ -49,12 +49,7 @@ class GivensAnsatzOperator:
     ) -> np.ndarray:
         """Apply the operator to a vector."""
         return apply_orbital_rotation(
-            vec,
-            self.to_orbital_rotation(),
-            norb=norb,
-            nelec=nelec,
-            copy=copy,
-            validate=False,
+            vec, self.to_orbital_rotation(), norb=norb, nelec=nelec, copy=copy
         )
 
     def to_parameters(self) -> np.ndarray:

--- a/tests/python/_slow/gates/diag_coulomb_test.py
+++ b/tests/python/_slow/gates/diag_coulomb_test.py
@@ -31,7 +31,7 @@ from ffsim._slow.gates.diag_coulomb import (
 @pytest.mark.parametrize("norb, nelec", ffsim.testing.generate_norb_nelec(range(6)))
 def test_apply_diag_coulomb_evolution_num_rep_slow(norb: int, nelec: tuple[int, int]):
     """Test applying time evolution of diagonal Coulomb operator."""
-    rng = np.random.default_rng()
+    rng = np.random.default_rng(40541)
     n_alpha, n_beta = nelec
     dim_a = math.comb(norb, n_alpha)
     dim_b = math.comb(norb, n_beta)
@@ -73,7 +73,7 @@ def test_apply_diag_coulomb_evolution_num_rep_slow(norb: int, nelec: tuple[int, 
 @pytest.mark.parametrize("norb, nelec", ffsim.testing.generate_norb_nelec(range(6)))
 def test_apply_diag_coulomb_evolution_z_rep_slow(norb: int, nelec: tuple[int, int]):
     """Test applying time evolution of diagonal Coulomb operator."""
-    rng = np.random.default_rng()
+    rng = np.random.default_rng(744)
     n_alpha, n_beta = nelec
     dim_a = math.comb(norb, n_alpha)
     dim_b = math.comb(norb, n_beta)
@@ -121,7 +121,7 @@ def test_apply_diag_coulomb_evolution_z_rep_slow(norb: int, nelec: tuple[int, in
 @pytest.mark.parametrize("norb, nelec", ffsim.testing.generate_norb_nelec(range(6)))
 def test_apply_diag_coulomb_evolution_num_rep_numpy(norb: int, nelec: tuple[int, int]):
     """Test applying time evolution of diag Coulomb operator, numpy implementation."""
-    rng = np.random.default_rng()
+    rng = np.random.default_rng(31267)
     n_alpha, n_beta = nelec
     dim_a = math.comb(norb, n_alpha)
     dim_b = math.comb(norb, n_beta)

--- a/tests/python/gates/num_op_sum_test.py
+++ b/tests/python/gates/num_op_sum_test.py
@@ -13,7 +13,6 @@
 from __future__ import annotations
 
 import numpy as np
-import pytest
 import scipy.linalg
 import scipy.sparse.linalg
 
@@ -52,21 +51,6 @@ def test_apply_num_op_sum_evolution():
 
         np.testing.assert_allclose(result, expected)
         np.testing.assert_allclose(state, original_state)
-
-
-def test_apply_num_op_sum_evolution_wrong_coeffs_length():
-    """Test passing wrong coeffs length raises correct error."""
-    norb = 5
-    nelec = (3, 2)
-    n_alpha, n_beta = nelec
-    occupied_orbitals = (range(n_alpha), range(n_beta))
-    state = ffsim.slater_determinant(norb, occupied_orbitals)
-
-    coeffs = np.ones(norb - 1)
-    with pytest.raises(ValueError, match="length"):
-        _ = ffsim.apply_num_op_sum_evolution(
-            state, coeffs, time=1.0, norb=norb, nelec=nelec
-        )
 
 
 def test_apply_quadratic_hamiltonian_evolution():


### PR DESCRIPTION
It has a non-negligible impact on performance. Validation should be done at a higher level (e.g. it's still done for the Qiskit gates).