### PR TITLE
increase pyscf requirement to 2.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 dependencies = [
     "numpy",
     "opt_einsum",
-    "pyscf >= 2.3",
+    "pyscf >= 2.4",
     "qiskit >= 1.1",
     "scipy",
     "typing-extensions",


### PR DESCRIPTION
In 2.3, the following code crashes with `zsh: floating point exception`:
```python
from pyscf.fci import cistring

linkstr_index_a = cistring.gen_linkstr_index(range(23), 3)
```