### PR TITLE
don't attempt to compute dipole integrals and orbital symmetries

### DIFF
--- a/python/ffsim/molecular_data.py
+++ b/python/ffsim/molecular_data.py
@@ -175,29 +175,6 @@ class MolecularData:
         one_body_tensor, core_energy = cas.get_h1cas(mo)
         two_body_integrals = cas.get_h2cas(mo)
 
-        # Get dipole integrals.
-        charges = mol.atom_charges()
-        coords = mol.atom_coords()
-        nuc_charge_center = np.einsum("z,zx->x", charges, coords) / charges.sum()
-        with mol.with_common_origin(nuc_charge_center):
-            dipole_integrals = mol.intor("cint1e_r_sph", comp=3)
-            mo_coeffs = hartree_fock.mo_coeff[:, active_space]
-            dipole_integrals = np.einsum(
-                "xij,ip,jq->xpq", dipole_integrals, mo_coeffs, mo_coeffs
-            )
-
-        # Get orbital symmetries.
-        orbsym = None
-        if mol.symmetry:
-            orbsym = list(
-                pyscf.symm.label_orb_symm(
-                    mol,
-                    mol.irrep_name,
-                    mol.symm_orb,
-                    hartree_fock.mo_coeff[:, active_space],
-                )
-            )
-
         return MolecularData(
             core_energy=core_energy,
             one_body_integrals=one_body_tensor,
@@ -212,8 +189,6 @@ class MolecularData:
             mo_occ=hartree_fock.mo_occ,
             active_space=active_space,
             hf_energy=hf_energy,
-            dipole_integrals=dipole_integrals,
-            orbital_symmetries=orbsym,
         )
 
     @staticmethod

--- a/tests/python/molecular_data_test.py
+++ b/tests/python/molecular_data_test.py
@@ -45,35 +45,6 @@ def _assert_mol_data_equal(
             assert actual == expected
 
 
-def test_molecular_data_sym():
-    # Build N2 molecule
-    mol = pyscf.gto.Mole()
-    mol.build(
-        atom=[["N", (0, 0, 0)], ["N", (1.0, 0, 0)]],
-        basis="sto-6g",
-        symmetry="Dooh",
-    )
-
-    # Define active space
-    n_frozen = pyscf.data.elements.chemcore(mol)
-    active_space = range(n_frozen, mol.nao_nr())
-
-    # Get molecular data and Hamiltonian
-    scf = pyscf.scf.RHF(mol).run()
-    mol_data = ffsim.MolecularData.from_scf(scf, active_space=active_space)
-
-    assert mol_data.orbital_symmetries == [
-        "A1g",
-        "A1u",
-        "E1uy",
-        "E1ux",
-        "A1g",
-        "E1gx",
-        "E1gy",
-        "A1u",
-    ]
-
-
 def test_molecular_data_no_sym():
     # Build N2 molecule
     mol = pyscf.gto.Mole()


### PR DESCRIPTION
in MolecularData. It doesn't work if the SCF object doesn't have all its properties initialized, such as when it's initialized using `pyscf.tools.fcidump.to_scf`.