### PR TITLE
use nao instead of nao_nr()

### DIFF
--- a/python/ffsim/molecular_data.py
+++ b/python/ffsim/molecular_data.py
@@ -142,7 +142,7 @@ class MolecularData:
 
         # Get core energy and one- and two-body integrals.
         if active_space is None:
-            norb = mol.nao_nr()
+            norb = mol.nao
             active_space = range(norb)
         active_space = list(active_space)
         norb = len(active_space)


### PR DESCRIPTION
This works for an SCF that was loaded from an FCIDUMP file. See https://github.com/pyscf/pyscf/issues/2303.