### PR TITLE
Add method to convert MolecularHamiltonian to MPO

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "qiskit >= 1.1",
     "scipy",
     "typing-extensions",
+    "physics-tenpy"
 ]
 
 [project.urls]

--- a/python/ffsim/hamiltonians/molecular_hamiltonian.py
+++ b/python/ffsim/hamiltonians/molecular_hamiltonian.py
@@ -25,6 +25,7 @@ from typing_extensions import deprecated
 from ffsim.cistring import gen_linkstr_index
 from ffsim.operators import FermionOperator, cre_a, cre_b, des_a, des_b
 from ffsim.states import dim
+from ffsim.tenpy.hamiltonians import MolecularHamiltonianMPO
 
 
 @dataclasses.dataclass(frozen=True)
@@ -119,6 +120,41 @@ class MolecularHamiltonian:
             two_body_tensor=two_body_tensor_rotated,
             constant=self.constant,
         )
+
+    def to_mpo(self, decimal_places=None):
+        r"""Return the Hamiltonian as an MPO.
+
+        Args:
+            decimal_places: The number of decimal places to which to round the input
+                one-body and two-body tensors. Rounding can sometimes reduce the MPO
+                bond dimension.
+
+        Return type:
+            `TeNPy MPO <https://tenpy.readthedocs.io/en/latest/reference/tenpy.networks.mpo.MPO.html#tenpy.networks.mpo.MPO>`__
+
+        Returns:
+            The Hamiltonian as an MPO.
+        """
+
+        if decimal_places:
+            one_body_tensor = np.round(self.one_body_tensor, decimals=decimal_places)
+            two_body_tensor = np.round(self.two_body_tensor, decimals=decimal_places)
+        else:
+            one_body_tensor = self.one_body_tensor
+            two_body_tensor = self.two_body_tensor
+
+        model_params = dict(
+            cons_N="N",
+            cons_Sz="Sz",
+            L=1,
+            norb=self.norb,
+            one_body_tensor=one_body_tensor,
+            two_body_tensor=two_body_tensor,
+            constant=self.constant,
+        )
+        mpo_model = MolecularHamiltonianMPO(model_params)
+
+        return mpo_model.H_MPO
 
     def _linear_operator_(self, norb: int, nelec: tuple[int, int]) -> LinearOperator:
         """Return a SciPy LinearOperator representing the object."""

--- a/python/ffsim/tenpy/hamiltonians/__init__.py
+++ b/python/ffsim/tenpy/hamiltonians/__init__.py
@@ -1,0 +1,21 @@
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Classes for converting Hamiltonians to TeNPy MPO objects."""
+
+from ffsim.tenpy.hamiltonians.molecular_hamiltonian import (
+    MolecularChain,
+    MolecularHamiltonianMPO,
+)
+
+__all__ = [
+    "MolecularChain",
+    "MolecularHamiltonianMPO",
+]

--- a/python/ffsim/tenpy/hamiltonians/molecular_hamiltonian.py
+++ b/python/ffsim/tenpy/hamiltonians/molecular_hamiltonian.py
@@ -1,0 +1,111 @@
+import numpy as np
+from tenpy.models.lattice import Lattice
+from tenpy.models.model import CouplingMPOModel
+from tenpy.networks.site import SpinHalfFermionSite
+
+# ignore lowercase argument and variable checks to maintain TeNPy naming conventions
+# ruff: noqa: N803, N806
+
+
+class MolecularChain(Lattice):
+    def __init__(self, L, norb, site_a, **kwargs):
+        basis = np.array(([norb, 0.0], [0, 1]))
+        pos = np.array([[i, 0] for i in range(norb)])
+
+        kwargs.setdefault("order", "default")
+        kwargs.setdefault("bc", "open")
+        kwargs.setdefault("bc_MPS", "finite")
+        kwargs.setdefault("basis", basis)
+        kwargs.setdefault("positions", pos)
+
+        super().__init__([L, 1], [site_a] * norb, **kwargs)
+
+
+class MolecularHamiltonianMPO(CouplingMPOModel):
+    def __init__(self, params):
+        CouplingMPOModel.__init__(self, params)
+
+    def init_sites(self, params):
+        cons_N = params.get("cons_N", "N")
+        cons_Sz = params.get("cons_Sz", "Sz")
+        site = SpinHalfFermionSite(cons_N=cons_N, cons_Sz=cons_Sz)
+        print(sorted(site.opnames))
+        print(site.state_labels)
+        return site
+
+    def init_lattice(self, params):
+        L = params.get("L", 1)
+        norb = params.get("norb", 4)
+        site = self.init_sites(params)
+        lat = MolecularChain(L, norb, site, basis=[[norb, 0], [0, 1]])
+        return lat
+
+    def init_terms(self, params):
+        dx0 = np.array([0, 0])
+        norb = params.get("norb", 4)
+        one_body_tensor = params.get("one_body_tensor", np.zeros((norb, norb)))
+        two_body_tensor = params.get(
+            "two_body_tensor", np.zeros((norb, norb, norb, norb))
+        )
+        constant = params.get("constant", 0)
+
+        for p in range(norb):
+            for q in range(norb):
+                h1 = one_body_tensor[p, q]
+                if p == q:
+                    self.add_onsite(h1, p, "Nu")
+                    self.add_onsite(h1, p, "Nd")
+                    self.add_onsite(constant / norb, p, "Id")
+                else:
+                    self.add_coupling(h1, p, "Cdu", q, "Cu", dx0)
+                    self.add_coupling(h1, p, "Cdd", q, "Cd", dx0)
+
+                for r in range(norb):
+                    for s in range(norb):
+                        h2 = two_body_tensor[p, q, r, s]
+                        if p == q == r == s:
+                            self.add_onsite(h2 / 2, p, "Nu")
+                            self.add_onsite(-h2 / 2, p, "Nu Nu")
+                            self.add_onsite(h2 / 2, p, "Nu")
+                            self.add_onsite(-h2 / 2, p, "Cdu Cd Cdd Cu")
+                            self.add_onsite(h2 / 2, p, "Nd")
+                            self.add_onsite(-h2 / 2, p, "Cdd Cu Cdu Cd")
+                            self.add_onsite(h2 / 2, p, "Nd")
+                            self.add_onsite(-h2 / 2, p, "Nd Nd")
+                        else:
+                            self.add_multi_coupling(
+                                h2 / 2,
+                                [
+                                    ("Cdu", dx0, p),
+                                    ("Cdu", dx0, r),
+                                    ("Cu", dx0, s),
+                                    ("Cu", dx0, q),
+                                ],
+                            )
+                            self.add_multi_coupling(
+                                h2 / 2,
+                                [
+                                    ("Cdu", dx0, p),
+                                    ("Cdd", dx0, r),
+                                    ("Cd", dx0, s),
+                                    ("Cu", dx0, q),
+                                ],
+                            )
+                            self.add_multi_coupling(
+                                h2 / 2,
+                                [
+                                    ("Cdd", dx0, p),
+                                    ("Cdu", dx0, r),
+                                    ("Cu", dx0, s),
+                                    ("Cd", dx0, q),
+                                ],
+                            )
+                            self.add_multi_coupling(
+                                h2 / 2,
+                                [
+                                    ("Cdd", dx0, p),
+                                    ("Cdd", dx0, r),
+                                    ("Cd", dx0, s),
+                                    ("Cd", dx0, q),
+                                ],
+                            )

--- a/python/ffsim/tenpy/util.py
+++ b/python/ffsim/tenpy/util.py
@@ -1,0 +1,46 @@
+from tenpy.networks.mps import MPS
+from tenpy.networks.site import SpinHalfFermionSite
+
+import ffsim
+
+
+def product_state_to_mps(norb, nelec, idx):
+    r"""Return the product state as an MPS.
+
+    Return type:
+        `TeNPy MPS <https://tenpy.readthedocs.io/en/latest/reference/tenpy.networks.mps.MPS.html#tenpy.networks.mps.MPS>`__
+
+    Returns:
+        The product state as an MPS.
+    """
+
+    dim = ffsim.dim(norb, nelec)
+
+    strings = ffsim.addresses_to_strings(
+        range(dim), norb=norb, nelec=nelec, bitstring_type=ffsim.BitstringType.STRING
+    )
+
+    string = strings[idx]
+    up_sector = list(string[0:norb].replace("1", "u"))
+    down_sector = list(string[norb : 2 * norb].replace("1", "d"))
+    product_state = list(map(lambda x, y: x + y, up_sector, down_sector))
+
+    for i, site in enumerate(product_state):
+        if site == "00":
+            product_state[i] = "empty"
+        elif site == "u0":
+            product_state[i] = "up"
+        elif site == "0d":
+            product_state[i] = "down"
+        elif site == "ud":
+            product_state[i] = "full"
+        else:
+            raise ValueError("undefined site")
+
+    # note that the bit positions increase from right to left
+    product_state = product_state[::-1]
+
+    shfs = SpinHalfFermionSite(cons_N="N", cons_Sz="Sz")
+    psi_mps = MPS.from_product_state([shfs] * norb, product_state)
+
+    return psi_mps


### PR DESCRIPTION
I have added a method to the `MolecularHamiltonian` class that can convert it to an MPO. Following the convention used for `qiskit`, I added a `tenpy` directory, with a `util.py` file. It also has a `hamiltonians` directory, anticipating other Hamiltonians to be implemented in the future.