### PR TITLE
Add double_factorized_t2_compress

### DIFF
--- a/python/ffsim/linalg/double_factorized_decomposition_compressed.py
+++ b/python/ffsim/linalg/double_factorized_decomposition_compressed.py
@@ -234,7 +234,7 @@ def double_factorized_t2_compressed(
         diag_coulomb_mask[rows, cols] = True
         diag_coulomb_mask[cols, rows] = True
 
-    # diag_coulomb_mask
+    # construct diag_coulomb_mask indices
     diag_coulomb_mask_indices = np.triu(diag_coulomb_mask)
 
     list_reps = list(range(begin_reps, n_reps, -step))


### PR DESCRIPTION
Add function `double_factorized_t2_compress` to optimize truncated t2 amplitude. Required Jax.