### PR TITLE
Qiskit gates: Support CCZGate and CRZGate

### DIFF
--- a/python/ffsim/qiskit/sim.py
+++ b/python/ffsim/qiskit/sim.py
@@ -290,7 +290,7 @@ def _evolve_state_vector_spinless(
             math.pi,
             target_orbs=([i, j, k], []),
             norb=norb,
-            nelec=(nelec, 0),
+            nelec=(cast(int, nelec), 0),
             copy=False,
         )
         return states.StateVector(vec=vec, norb=norb, nelec=nelec)

--- a/python/ffsim/qiskit/sim.py
+++ b/python/ffsim/qiskit/sim.py
@@ -285,7 +285,6 @@ def _evolve_state_vector_spinless(
 
     if isinstance(op, CCZGate):
         i, j, k = qubit_indices
-        assert isinstance(nelec, int)
         vec = gates.apply_num_op_prod_interaction(
             vec,
             math.pi,
@@ -498,6 +497,9 @@ def _evolve_state_vector_spinful(
     if isinstance(op, CRZGate):
         control, target = qubit_indices
         (theta,) = op.params
+        target_orbs = ([], [])
+        target_orbs[control >= norb].append(control % norb)
+        target_orbs[target >= norb].append(target % norb)
         vec = gates.apply_num_interaction(
             vec,
             -0.5 * theta,
@@ -507,9 +509,6 @@ def _evolve_state_vector_spinful(
             spin=Spin.ALPHA if control < norb else Spin.BETA,
             copy=False,
         )
-        target_orbs = ([], [])
-        target_orbs[control >= norb].append(control % norb)
-        target_orbs[target >= norb].append(target % norb)
         vec = gates.apply_num_op_prod_interaction(
             vec, theta, target_orbs=target_orbs, norb=norb, nelec=nelec, copy=False
         )

--- a/tests/python/qiskit/sim_test.py
+++ b/tests/python/qiskit/sim_test.py
@@ -166,6 +166,8 @@ def test_qiskit_gates_spinful(norb: int, nelec: tuple[int, int]):
     prng.shuffle(pairs)
     big_pairs = list(itertools.combinations(range(2 * norb), 2))
     prng.shuffle(big_pairs)
+    triples = list(itertools.combinations(range(2 * norb), 3))
+    prng.shuffle(triples)
 
     # Construct circuit
     qubits = QuantumRegister(2 * norb)
@@ -190,8 +192,6 @@ def test_qiskit_gates_spinful(norb: int, nelec: tuple[int, int]):
         circuit.append(CPhaseGate(rng.uniform(-10, 10)), [qubits[i], qubits[j]])
         circuit.append(CRZGate(rng.uniform(-10, 10)), [qubits[i], qubits[j]])
         circuit.append(CZGate(), [qubits[i], qubits[j]])
-    triples = list(itertools.combinations(range(2 * norb), 3))
-    prng.shuffle(triples)
     for i, j, k in triples:
         circuit.append(CCZGate(), [qubits[i], qubits[j], qubits[k]])
     for i, j in pairs:
@@ -240,8 +240,8 @@ def test_qiskit_gates_spinless(norb: int, nocc: int):
     prng = random.Random(11832)
     pairs = list(itertools.combinations(range(norb), 2))
     prng.shuffle(pairs)
-    big_pairs = list(itertools.combinations(range(norb), 2))
-    prng.shuffle(big_pairs)
+    triples = list(itertools.combinations(range(norb), 3))
+    prng.shuffle(triples)
 
     # Construct circuit
     qubits = QuantumRegister(norb)
@@ -255,14 +255,12 @@ def test_qiskit_gates_spinless(norb: int, nocc: int):
         )
     for q in qubits:
         circuit.append(PhaseGate(rng.uniform(-10, 10)), [q])
-    for i, j in big_pairs:
+    for i, j in pairs:
         circuit.append(CPhaseGate(rng.uniform(-10, 10)), [qubits[i], qubits[j]])
         circuit.append(CRZGate(rng.uniform(-10, 10)), [qubits[i], qubits[j]])
         circuit.append(CZGate(), [qubits[i], qubits[j]])
     for i, j in pairs:
         circuit.append(iSwapGate(), [qubits[i], qubits[j]])
-    triples = list(itertools.combinations(range(norb), 3))
-    prng.shuffle(triples)
     for i, j, k in triples:
         circuit.append(CCZGate(), [qubits[i], qubits[j], qubits[k]])
     for q in qubits:

--- a/tests/python/qiskit/sim_test.py
+++ b/tests/python/qiskit/sim_test.py
@@ -19,7 +19,9 @@ import numpy as np
 import pytest
 from qiskit.circuit import QuantumCircuit, QuantumRegister
 from qiskit.circuit.library import (
+    CCZGate,
     CPhaseGate,
+    CRZGate,
     CZGate,
     GlobalPhaseGate,
     PhaseGate,
@@ -186,7 +188,12 @@ def test_qiskit_gates_spinful(norb: int, nelec: tuple[int, int]):
         circuit.append(PhaseGate(rng.uniform(-10, 10)), [q])
     for i, j in big_pairs:
         circuit.append(CPhaseGate(rng.uniform(-10, 10)), [qubits[i], qubits[j]])
+        circuit.append(CRZGate(rng.uniform(-10, 10)), [qubits[i], qubits[j]])
         circuit.append(CZGate(), [qubits[i], qubits[j]])
+    triples = list(itertools.combinations(range(2 * norb), 3))
+    prng.shuffle(triples)
+    for i, j, k in triples:
+        circuit.append(CCZGate(), [qubits[i], qubits[j], qubits[k]])
     for i, j in pairs:
         circuit.append(iSwapGate(), [qubits[i], qubits[j]])
         circuit.append(iSwapGate(), [qubits[norb + i], qubits[norb + j]])
@@ -233,6 +240,8 @@ def test_qiskit_gates_spinless(norb: int, nocc: int):
     prng = random.Random(11832)
     pairs = list(itertools.combinations(range(norb), 2))
     prng.shuffle(pairs)
+    big_pairs = list(itertools.combinations(range(norb), 2))
+    prng.shuffle(big_pairs)
 
     # Construct circuit
     qubits = QuantumRegister(norb)
@@ -246,10 +255,16 @@ def test_qiskit_gates_spinless(norb: int, nocc: int):
         )
     for q in qubits:
         circuit.append(PhaseGate(rng.uniform(-10, 10)), [q])
-    for i, j in pairs:
+    for i, j in big_pairs:
         circuit.append(CPhaseGate(rng.uniform(-10, 10)), [qubits[i], qubits[j]])
+        circuit.append(CRZGate(rng.uniform(-10, 10)), [qubits[i], qubits[j]])
         circuit.append(CZGate(), [qubits[i], qubits[j]])
+    for i, j in pairs:
         circuit.append(iSwapGate(), [qubits[i], qubits[j]])
+    triples = list(itertools.combinations(range(norb), 3))
+    prng.shuffle(triples)
+    for i, j, k in triples:
+        circuit.append(CCZGate(), [qubits[i], qubits[j], qubits[k]])
     for q in qubits:
         circuit.append(RZGate(rng.uniform(-10, 10)), [q])
     for i, j in pairs:


### PR DESCRIPTION
Part of #369 

## Summary
This PR adds support for Qiskit's `CCZGate` and `CRZGate` to the fermionic simulator.
Added unit-tests accordingly.

### CCZGate handling:
- For spinless circuits, three qubits indices `(i, j, k)` are mapped to spatial orbitals. This applies

$$U_{CCZ} = exp(i \pi n_i n_j n_k)$$

- For spinful circuits, qubit indices are mapped to a pair of lists `(S_α, S_β)`. This applies

$$ U_{CCZ} = exp\left(i \pi \prod_{p \in S_\alpha} n_{\alpha, p} \prod_{q \in S_\beta} n_{\beta,q}\right)$$

### CRZGate handling:
- For spinless circuits, a controlled - $R_z(\theta)$ on qubits `(control, target)` is decomposed into two diagonal fermionic unitaries:

$$U_{CRZ}(\theta) = exp\left(-i \frac{\theta}{2} n_{control}\right) exp\left(i \theta n_{control} n_{target}\right).$$

- For spinful circuits, it applies a half-angle number interaction on the control orbital within its spin sector and then appleis a two-body interaction with $p_c = control \mod norb$, $p_t = target \mod norb$

$$U_{CRZ}(\theta) = exp\left(- i \frac{\theta}{2} n_{\sigma_c, p_c}\right) exp \left(i \theta n_{\sigma_c, p_c} n_{\sigma_t, p_t} \right).$$
