### PR TITLE
Qiskit gates: Support CSGate and CSdgGate

### DIFF
--- a/python/ffsim/qiskit/sim.py
+++ b/python/ffsim/qiskit/sim.py
@@ -23,6 +23,8 @@ from qiskit.circuit.library import (
     CCZGate,
     CPhaseGate,
     CRZGate,
+    CSdgGate,
+    CSGate,
     CZGate,
     GlobalPhaseGate,
     Measure,
@@ -255,6 +257,20 @@ def _evolve_state_vector_spinless(
         )
         return states.StateVector(vec=vec, norb=norb, nelec=nelec)
 
+    if isinstance(op, CSGate):
+        i, j = qubit_indices
+        vec = gates.apply_num_num_interaction(
+            vec, 0.5 * math.pi, target_orbs=(i, j), norb=norb, nelec=nelec, copy=False
+        )
+        return states.StateVector(vec=vec, norb=norb, nelec=nelec)
+
+    if isinstance(op, CSdgGate):
+        i, j = qubit_indices
+        vec = gates.apply_num_num_interaction(
+            vec, -0.5 * math.pi, target_orbs=(i, j), norb=norb, nelec=nelec, copy=False
+        )
+        return states.StateVector(vec=vec, norb=norb, nelec=nelec)
+
     if isinstance(op, PhaseGate):
         (orb,) = qubit_indices
         (theta,) = op.params
@@ -472,6 +488,36 @@ def _evolve_state_vector_spinful(
         target_orbs[j >= norb].append(j % norb)
         vec = gates.apply_num_op_prod_interaction(
             vec, math.pi, target_orbs=target_orbs, norb=norb, nelec=nelec, copy=False
+        )
+        return states.StateVector(vec=vec, norb=norb, nelec=nelec)
+
+    if isinstance(op, CSGate):
+        i, j = qubit_indices
+        target_orbs = ([], [])
+        target_orbs[i >= norb].append(i % norb)
+        target_orbs[j >= norb].append(j % norb)
+        vec = gates.apply_num_op_prod_interaction(
+            vec,
+            0.5 * math.pi,
+            target_orbs=target_orbs,
+            norb=norb,
+            nelec=nelec,
+            copy=False,
+        )
+        return states.StateVector(vec=vec, norb=norb, nelec=nelec)
+
+    if isinstance(op, CSdgGate):
+        i, j = qubit_indices
+        target_orbs = ([], [])
+        target_orbs[i >= norb].append(i % norb)
+        target_orbs[j >= norb].append(j % norb)
+        vec = gates.apply_num_op_prod_interaction(
+            vec,
+            -0.5 * math.pi,
+            target_orbs=target_orbs,
+            norb=norb,
+            nelec=nelec,
+            copy=False,
         )
         return states.StateVector(vec=vec, norb=norb, nelec=nelec)
 

--- a/tests/python/qiskit/sim_test.py
+++ b/tests/python/qiskit/sim_test.py
@@ -22,6 +22,8 @@ from qiskit.circuit.library import (
     CCZGate,
     CPhaseGate,
     CRZGate,
+    CSdgGate,
+    CSGate,
     CZGate,
     GlobalPhaseGate,
     PhaseGate,
@@ -192,6 +194,8 @@ def test_qiskit_gates_spinful(norb: int, nelec: tuple[int, int]):
         circuit.append(CPhaseGate(rng.uniform(-10, 10)), [qubits[i], qubits[j]])
         circuit.append(CRZGate(rng.uniform(-10, 10)), [qubits[i], qubits[j]])
         circuit.append(CZGate(), [qubits[i], qubits[j]])
+        circuit.append(CSGate(), [qubits[i], qubits[j]])
+        circuit.append(CSdgGate(), [qubits[i], qubits[j]])
     for i, j, k in triples:
         circuit.append(CCZGate(), [qubits[i], qubits[j], qubits[k]])
     for i, j in pairs:
@@ -259,6 +263,8 @@ def test_qiskit_gates_spinless(norb: int, nocc: int):
         circuit.append(CPhaseGate(rng.uniform(-10, 10)), [qubits[i], qubits[j]])
         circuit.append(CRZGate(rng.uniform(-10, 10)), [qubits[i], qubits[j]])
         circuit.append(CZGate(), [qubits[i], qubits[j]])
+        circuit.append(CSGate(), [qubits[i], qubits[j]])
+        circuit.append(CSdgGate(), [qubits[i], qubits[j]])
     for i, j in pairs:
         circuit.append(iSwapGate(), [qubits[i], qubits[j]])
     for i, j, k in triples:

--- a/tests/python/qiskit/sim_test.py
+++ b/tests/python/qiskit/sim_test.py
@@ -192,9 +192,17 @@ def test_qiskit_gates_spinful(norb: int, nelec: tuple[int, int]):
         circuit.append(PhaseGate(rng.uniform(-10, 10)), [q])
     for i, j in big_pairs:
         circuit.append(CPhaseGate(rng.uniform(-10, 10)), [qubits[i], qubits[j]])
+    prng.shuffle(big_pairs)
+    for i, j in big_pairs:
         circuit.append(CRZGate(rng.uniform(-10, 10)), [qubits[i], qubits[j]])
+    prng.shuffle(big_pairs)
+    for i, j in big_pairs:
         circuit.append(CZGate(), [qubits[i], qubits[j]])
+    prng.shuffle(big_pairs)
+    for i, j in big_pairs:
         circuit.append(CSGate(), [qubits[i], qubits[j]])
+    prng.shuffle(big_pairs)
+    for i, j in big_pairs:
         circuit.append(CSdgGate(), [qubits[i], qubits[j]])
     for i, j, k in triples:
         circuit.append(CCZGate(), [qubits[i], qubits[j], qubits[k]])
@@ -261,9 +269,17 @@ def test_qiskit_gates_spinless(norb: int, nocc: int):
         circuit.append(PhaseGate(rng.uniform(-10, 10)), [q])
     for i, j in pairs:
         circuit.append(CPhaseGate(rng.uniform(-10, 10)), [qubits[i], qubits[j]])
+    prng.shuffle(pairs)
+    for i, j in pairs:
         circuit.append(CRZGate(rng.uniform(-10, 10)), [qubits[i], qubits[j]])
+    prng.shuffle(pairs)
+    for i, j in pairs:
         circuit.append(CZGate(), [qubits[i], qubits[j]])
+    prng.shuffle(pairs)
+    for i, j in pairs:
         circuit.append(CSGate(), [qubits[i], qubits[j]])
+    prng.shuffle(pairs)
+    for i, j in pairs:
         circuit.append(CSdgGate(), [qubits[i], qubits[j]])
     for i, j in pairs:
         circuit.append(iSwapGate(), [qubits[i], qubits[j]])


### PR DESCRIPTION
Part of #369 

## Summary

This PR adds support for Qiskit’s `CSGate` and `CSdgGate` to the fermionic simulator. 
Added unit-tests accordingly.

### CSGate handling

- For spinless circuits, two qubit indices $(i,j)$ mapped to spatial orbitals. Thils applies
  
$$U_{\mathrm{CS}} = \exp\left(i\tfrac{\pi}{2}n_in_j\right).$$

- For spinful circuits, each qubit index is mapped to either the α‑ or β‑spin sector.  The gate applies
  
$$U_{\mathrm{CS}}
    = \exp\left(i\tfrac{\pi}{2}\prod_{p\in S_\alpha}n_{\alpha,p}
        \prod_{q\in S_\beta}n_{\beta,q}\right).$$

### CSdgGate handling

- For spinless circuits, the adjoint controlled‑ $S$ gate applies a conditional phase of $-i$.  This is realized by
 
$$U_{\mathrm{CS^\dagger}}
    = \exp\left(-i\tfrac{\pi}{2}n_in_j\right).$$

- For spinful circuits, using the same mapping of qubits to $(S_\alpha,S_\beta)$ as above, the gate applies
 
$$U_{\mathrm{CS^\dagger}}
    = \exp\left(-i\tfrac{\pi}{2}
        \prod_{p\in S_\alpha}n_{\alpha,p}
        \prod_{q\in S_\beta}n_{\beta,q}\right).$$


