### PR TITLE
Qiskit gates: Support DiagonalGate

### DIFF
--- a/tests/python/qiskit/sim_test.py
+++ b/tests/python/qiskit/sim_test.py
@@ -222,6 +222,9 @@ def test_qiskit_gates_spinful(norb: int, nelec: tuple[int, int]):
         circuit.append(SwapGate(), [qubits[i], qubits[j]])
         circuit.append(SwapGate(), [qubits[norb + i], qubits[norb + j]])
     circuit.append(GlobalPhaseGate(rng.uniform(-10, 10)))
+    chosen = rng.choice(2 * norb, size=min(3, 2 * norb), replace=False)
+    diag = np.exp(1j * rng.uniform(-np.pi, np.pi, size=2 ** len(chosen)))
+    circuit.append(DiagonalGate(diag), [qubits[i] for i in chosen])
 
     # Compute state vector using ffsim
     ffsim_vec = ffsim.qiskit.final_state_vector(circuit, norb=norb, nelec=nelec)
@@ -289,6 +292,9 @@ def test_qiskit_gates_spinless(norb: int, nocc: int):
     for i, j in prng.choices(pairs, k=len(pairs) // 2):
         circuit.append(SwapGate(), [qubits[i], qubits[j]])
     circuit.append(GlobalPhaseGate(rng.uniform(-10, 10)))
+    chosen = rng.choice(norb, size=min(3, norb), replace=False)
+    diag = np.exp(1j * rng.uniform(-np.pi, np.pi, size=2 ** len(chosen)))
+    circuit.append(DiagonalGate(diag), [qubits[i] for i in chosen])
 
     # Compute state vector using ffsim
     ffsim_vec = ffsim.qiskit.final_state_vector(circuit, norb=norb, nelec=nocc)
@@ -299,52 +305,6 @@ def test_qiskit_gates_spinless(norb: int, nocc: int):
     )
 
     # Check that the state vectors match
-    np.testing.assert_allclose(ffsim_vec, qiskit_vec)
-
-
-@pytest.mark.parametrize(
-    "norb, nelec",
-    [
-        (norb, nelec)
-        for norb, nelec in ffsim.testing.generate_norb_nelec(range(1, 4))
-        if nelec != (0, 0)
-    ],
-)
-def test_diagonal_gate_spinful(norb: int, nelec: tuple[int, int]):
-    rng = np.random.default_rng(12285)
-    qubits = QuantumRegister(2 * norb)
-    circuit = QuantumCircuit(qubits)
-    circuit.append(ffsim.qiskit.PrepareHartreeFockJW(norb, nelec), qubits)
-    chosen = rng.choice(2 * norb, size=min(3, 2 * norb), replace=False)
-    diag = np.exp(1j * rng.uniform(-np.pi, np.pi, size=2 ** len(chosen)))
-    circuit.append(DiagonalGate(diag), [qubits[i] for i in chosen])
-    ffsim_vec = ffsim.qiskit.final_state_vector(circuit, norb=norb, nelec=nelec)
-    qiskit_vec = ffsim.qiskit.qiskit_vec_to_ffsim_vec(
-        Statevector(circuit).data, norb=norb, nelec=nelec
-    )
-    np.testing.assert_allclose(ffsim_vec, qiskit_vec)
-
-
-@pytest.mark.parametrize(
-    "norb, nocc",
-    [
-        (norb, nocc)
-        for norb, nocc in ffsim.testing.generate_norb_nocc(range(1, 4))
-        if nocc
-    ],
-)
-def test_diagonal_gate_spinless(norb: int, nocc: int):
-    rng = np.random.default_rng(12285)
-    qubits = QuantumRegister(norb)
-    circuit = QuantumCircuit(qubits)
-    circuit.append(ffsim.qiskit.PrepareHartreeFockSpinlessJW(norb, nocc), qubits)
-    chosen = rng.choice(norb, size=min(3, norb), replace=False)
-    diag = np.exp(1j * rng.uniform(-np.pi, np.pi, size=2 ** len(chosen)))
-    circuit.append(DiagonalGate(diag), [qubits[i] for i in chosen])
-    ffsim_vec = ffsim.qiskit.final_state_vector(circuit, norb=norb, nelec=nocc)
-    qiskit_vec = ffsim.qiskit.qiskit_vec_to_ffsim_vec(
-        Statevector(circuit).data, norb=norb, nelec=nocc
-    )
     np.testing.assert_allclose(ffsim_vec, qiskit_vec)
 
 


### PR DESCRIPTION
Part of #369 
## Summary
This PR adds support for Qiskit’s `DiagonalGate` to the fermionic simulator.
Added unit-tests accordingly.

### DiagonalGate
#### Spinless circuit
For `norb` spatial orbitals with a fixed number of electrons `nocc`, the simulator recognizes `DiagonalGate(diag)` acting on a subset of qubits `i_1, …, i_k`. If the many‑fermion state is

$$|\psi\rangle = \sum_\nu c_\nu |\nu \rangle,$$

where $\nu\in\lbrace0,1\rbrace^{n_{orb}}$ has exactly `nocc` ones, the diagonal gate multiplies each amplitude by a phase from `diag`:

$$c\prime_{\nu} = \lambda_{r(\nu)} c_\nu, \qquad r(\nu)=\sum^k_{p=1} \nu_{i_p}2^{p-1}.$$

Here $r(\nu)$ encodes the occupation bits of $\nu$ at the selected qubit indices.

#### Spinful circult
For `norb` spatial orbitals and spin-resolved electron numbers, `nelec = (nα, nβ)`, the simulator uses `2*norb` qubits, arranged as $\beta$ -spin bit on left and $\alpha$ -spin bit on the right. A diagonal gate acting on qubits `i_1, …, i_k` computes the same binary index

$$r(\nu)=\sum^k_{p=1} s_\nu(i_p)2^{p-1},$$

where $s_\nu$ is the concatenated $2n_{orb}$ -bit string of a basis state. Each amplitude $c_\nu$ is then updated same as spinless case. 