### PR TITLE
Orbital optimization: Reshape params outside of JAX

### DIFF
--- a/python/ffsim/variational/orbital_optimization.py
+++ b/python/ffsim/variational/orbital_optimization.py
@@ -170,7 +170,9 @@ def optimize_orbitals(
     def fun(x: np.ndarray) -> tuple[float, np.ndarray]:
         generator = _generator_from_parameters(x, norb=norb, real=real)
         val, grad = value_and_grad(generator)
-        return val, _generator_to_parameters(grad, real=real)
+        # The complex conjugate of the gradient is actually returned
+        # See https://github.com/jax-ml/jax/issues/4891
+        return val, _generator_to_parameters(grad.conj(), real=real)
 
     if initial_orbital_rotation is None:
         initial_orbital_rotation = np.eye(norb)

--- a/tests/python/variational/orbital_optimization_test.py
+++ b/tests/python/variational/orbital_optimization_test.py
@@ -86,6 +86,6 @@ def test_optimize_orbitals():
     np.testing.assert_allclose(energy, -108.58613393502857)
     assert np.iscomplexobj(orbital_rotation)
     assert len(result.x) == norb**2
-    assert result.nit <= 8
-    assert result.nfev <= 11
-    assert result.njev <= 11
+    assert result.nit <= 12
+    assert result.nfev <= 14
+    assert result.njev <= 14

--- a/tests/python/variational/orbital_optimization_test.py
+++ b/tests/python/variational/orbital_optimization_test.py
@@ -64,9 +64,9 @@ def test_optimize_orbitals():
     np.testing.assert_allclose(energy, -108.58613393502857)
     assert np.isrealobj(orbital_rotation)
     assert len(result.x) == norb * (norb - 1) // 2
-    assert result.nit <= 7
-    assert result.nfev <= 9
-    assert result.njev <= 9
+    assert result.nit <= 8
+    assert result.nfev <= 10
+    assert result.njev <= 10
 
     # Optimize orbitals with complex rotations
     orbital_rotation, result = ffsim.optimize_orbitals(


### PR DESCRIPTION
This improves performance but something is wrong. The optimization with complex numbers gives a worse result than before.

```
>       np.testing.assert_allclose(energy, -108.58613393502857)
E       AssertionError:
E       Not equal to tolerance rtol=1e-07, atol=0
E
E       Mismatched elements: 1 / 1 (100%)
E       Max absolute difference among violations: 5.03683129e-05
E       Max relative difference among violations: 4.63855845e-07
E        ACTUAL: array(-108.586084)
E        DESIRED: array(-108.586134)

tests/python/variational/orbital_optimization_test.py:86: AssertionError
```