### PR TITLE
Drop Python 3.10

### DIFF
--- a/.github/workflows/test-latest-versions.yml
+++ b/.github/workflows/test-latest-versions.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
@@ -38,7 +38,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.13"]
+        python-version: ["3.11", "3.13"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
@@ -56,7 +56,7 @@ jobs:
     runs-on: macos-13
     strategy:
       matrix:
-        python-version: ["3.10", "3.13"]
+        python-version: ["3.11", "3.13"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python

--- a/.github/workflows/test-minimum-versions.yml
+++ b/.github/workflows/test-minimum-versions.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ tox run -e <environment name>
 
 substituting `<environment name>` with the name of the tox environment for the check. The following environments are available:
 
-- `py310`, `py311`, `py312`, `py313`: Run tests for a specific Python version
+- `py311`, `py312`, `py313`: Run tests for a specific Python version
 - `coverage`: Code coverage
 - `type`: Type check
 - `lint`: Lint check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ numpy = "0.21"
 pyo3 = { version = "0.21", features = [
     "extension-module",
     "num-complex",
-    "abi3-py310",
+    "abi3-py311",
 ] }
 num-integer = "0.1"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ffsim"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 version = "0.0.58.dev"
 description = "Faster simulations of fermionic quantum circuits."
 readme = "README.md"
@@ -13,7 +13,6 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -84,7 +83,7 @@ include = [
 select = ["E", "F", "I", "N", "NPY", "NPY201"]
 
 [tool.cibuildwheel]
-build = "cp310-macosx* cp310-manylinux_x86_64 cp310-manylinux_aarch64"
+build = "cp311-macosx* cp311-manylinux_x86_64 cp311-manylinux_aarch64"
 test-requires = "pytest"
 test-command = "pytest {project}/tests"
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 4.6.0
 env_list =
-    py{310,311,312,313}
+    py{311,312,313}
     coverage
     type
     lint


### PR DESCRIPTION
The motivation is to use some features only available in Scipy 1.16: https://docs.scipy.org/doc/scipy/release/1.16.0-notes.html#highlights-of-this-release