### PR TITLE
Add title and description metadata to notebooks

### DIFF
--- a/docs/explanations/double-factorized.ipynb
+++ b/docs/explanations/double-factorized.ipynb
@@ -116,7 +116,9 @@
    "pygments_lexer": "ipython3",
    "version": "3.11.8"
   },
-  "orig_nbformat": 4
+  "orig_nbformat": 4,
+  "title": "Double-Factorized Representations",
+  "description": "Understanding double-factorized representations of molecular Hamiltonians in quantum computing"
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/docs/explanations/hamiltonians.ipynb
+++ b/docs/explanations/hamiltonians.ipynb
@@ -207,7 +207,9 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.13.1"
-  }
+  },
+  "title": "Quantum Hamiltonians in ffsim",
+  "description": "Working with molecular and fermionic Hamiltonians in the ffsim quantum simulation framework"
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/docs/explanations/lucj.ipynb
+++ b/docs/explanations/lucj.ipynb
@@ -667,7 +667,9 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.12"
-  }
+  },
+  "title": "LUCJ Ansatz Explanation",
+  "description": "Comprehensive guide to the Linear Unitary Coupled-Cluster with generalized Singles and generalized pair doubles (LUCJ) ansatz"
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/docs/explanations/orbital-rotation.ipynb
+++ b/docs/explanations/orbital-rotation.ipynb
@@ -233,7 +233,9 @@
    "pygments_lexer": "ipython3",
    "version": "3.12.3"
   },
-  "orig_nbformat": 4
+  "orig_nbformat": 4,
+  "title": "Orbital Rotation Techniques",
+  "description": "Guide to implementing and understanding orbital rotations in quantum chemistry simulations"
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/docs/explanations/qiskit-gate-decompositions.ipynb
+++ b/docs/explanations/qiskit-gate-decompositions.ipynb
@@ -492,7 +492,9 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.12.4"
-  }
+  },
+  "title": "Qiskit Gate Decompositions",
+  "description": "Learn how to decompose quantum gates in Qiskit for efficient circuit implementation in ffsim"
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/docs/explanations/state-vectors-and-gates.ipynb
+++ b/docs/explanations/state-vectors-and-gates.ipynb
@@ -330,7 +330,9 @@
    "pygments_lexer": "ipython3",
    "version": "3.12.3"
   },
-  "orig_nbformat": 4
+  "orig_nbformat": 4,
+  "title": "State Vectors and Quantum Gates",
+  "description": "Fundamentals of state vectors and quantum gates implementation in ffsim"
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/docs/how-to-guides/entanglement-forging.ipynb
+++ b/docs/how-to-guides/entanglement-forging.ipynb
@@ -242,7 +242,9 @@
    "pygments_lexer": "ipython3",
    "version": "3.12.3"
   },
-  "orig_nbformat": 4
+  "orig_nbformat": 4,
+  "title": "Entanglement Forging Guide",
+  "description": "How to use entanglement forging techniques to reduce quantum resource requirements"
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/docs/how-to-guides/fermion-operator.ipynb
+++ b/docs/how-to-guides/fermion-operator.ipynb
@@ -454,7 +454,9 @@
    "pygments_lexer": "ipython3",
    "version": "3.13.1"
   },
-  "orig_nbformat": 4
+  "orig_nbformat": 4,
+  "title": "Working with Fermion Operators",
+  "description": "Guide to creating and manipulating fermion operators in ffsim"
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/docs/how-to-guides/qiskit-circuits-sim.ipynb
+++ b/docs/how-to-guides/qiskit-circuits-sim.ipynb
@@ -364,7 +364,9 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.12.3"
-  }
+  },
+  "title": "Simulating Qiskit Circuits",
+  "description": "How to efficiently simulate Qiskit quantum circuits using ffsim's optimized backends"
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/docs/how-to-guides/qiskit-lucj.ipynb
+++ b/docs/how-to-guides/qiskit-lucj.ipynb
@@ -239,7 +239,9 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.13.3"
-  }
+  },
+  "title": "LUCJ Implementation in Qiskit",
+  "description": "Implementing LUCJ ansatz circuits using Qiskit and ffsim integration"
  },
  "nbformat": 4,
  "nbformat_minor": 5

--- a/docs/how-to-guides/qiskit-merge-orbital-rotations.ipynb
+++ b/docs/how-to-guides/qiskit-merge-orbital-rotations.ipynb
@@ -186,7 +186,9 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.12.3"
-  }
+  },
+  "title": "Merging Orbital Rotations in Qiskit",
+  "description": "Optimize Qiskit circuits by merging consecutive orbital rotation gates"
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/docs/how-to-guides/simulate-lucj.ipynb
+++ b/docs/how-to-guides/simulate-lucj.ipynb
@@ -377,7 +377,9 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.10.12"
-  }
+  },
+  "title": "How to Simulate LUCJ Ansatz",
+  "description": "Practical guide for simulating the LUCJ ansatz for variational quantum algorithms"
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/docs/tutorials/double-factorized-trotter.ipynb
+++ b/docs/tutorials/double-factorized-trotter.ipynb
@@ -521,7 +521,9 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.12.3"
-  }
+  },
+  "title": "Double-Factorized Trotter Tutorial",
+  "description": "Step-by-step tutorial on implementing Trotter evolution with double-factorized Hamiltonians"
  },
  "nbformat": 4,
  "nbformat_minor": 2


### PR DESCRIPTION
## Summary
This PR adds title and description metadata to all Jupyter notebooks in the docs/ directory to improve SEO and discoverability.

## Changes
- Added `title` field to metadata of all 13 notebooks
- Added `description` field with SEO-friendly descriptions
- Preserved existing metadata (kernelspec, language_info)

## Motivation
As mentioned in #468, adding title and description to notebook metadata helps search engines find and index the content better.

## Testing
- Verified all notebooks still open correctly in Jupyter
- Confirmed metadata is properly formatted JSON
- Checked that existing metadata fields are preserved

Fixes #468