### PR TITLE
Build wheels for linux aarch64

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-13]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-13]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-latest-versions.yml
+++ b/.github/workflows/test-latest-versions.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, "ubuntu-24.04-arm"]
+        os: [ubuntu-latest, ubuntu-24.04-arm]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-latest-versions.yml
+++ b/.github/workflows/test-latest-versions.yml
@@ -14,9 +14,10 @@ permissions:
 
 jobs:
   test-linux:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, "ubuntu-24.04-arm"]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-latest-versions.yml
+++ b/.github/workflows/test-latest-versions.yml
@@ -14,11 +14,31 @@ permissions:
 
 jobs:
   test-linux:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt install -y libopenblas-dev
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install tox
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+      - name: Run tests
+        run: |
+          tox run -e py${{ matrix.python-version }}
+  test-linux-arm:
+    runs-on: ubuntu-24.04-arm
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.13"]
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies

--- a/.github/workflows/test-latest-versions.yml
+++ b/.github/workflows/test-latest-versions.yml
@@ -13,7 +13,7 @@ permissions:
   contents: read
 
 jobs:
-  test-linux:
+  test-linux-x86_64:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,19 @@ test-requires = "pytest"
 test-command = "pytest {project}/tests"
 
 [tool.cibuildwheel.linux]
-# mirrorlist.centos.org doesn't exist anymore
-# Workaround from https://serverfault.com/a/1161847
-before-all = "sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && yum install -y openssl-devel rust cargo openblas-devel"
+# Set the build image ONLY for aarch64.
+# x86_64 will continue to use its default (manylinux2014).
+manylinux-aarch64-image = "quay.io/pypa/manylinux_2_34_aarch64"
+
+before-all = """
+  set -ex
+  if [ "$(uname -m)" = "aarch64" ]; then
+    # new environment for aarch64 image
+    dnf install -y openssl-devel rust cargo openblas-devel
+  else
+    # Original environment for x86_64 linux
+    # mirrorlist.centos.org doesn't exist anymore
+    # Workaround from https://serverfault.com/a/1161847
+    sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && yum install -y openssl-devel rust cargo openblas-devel
+  fi
+"""


### PR DESCRIPTION
Builds wheel for linux aarch64
 - example scenario: Running Ubuntu containers on macOS (apple silicon)
 - avoids longer build time, requirement for tools, on a linux aarch64 system
 
 Fixes: #476
 Note: replaces earlier PR #475

Approach
 - Adds a matrix build using the Ubuntu 24.04 arm github runner
   - QEMU is an alternative, but more complexity to manage & slow
 - Uses a new manylinux (based on AlmaLinux 9) image for aarch64 only
   - existing x86_64 left untouched
   - problems experienced getting dependencies on centos 7 based distro
   
Testing
  - Build/CI only
  - Run on fork: https://github.com/planetf1/ffsim/actions/runs/17799758526 (without pypi publish)
  - Local install

Was able to install within `docker run -it ubuntu /bin/sh` on macOS silicon. Checked arch was aarch64, then unzipped the artifact above:

```
# unzip *.2
Archive:  698de5e9f84255824450be6cdfced092f717a888df8f34dbfa2383885cce5485.zip?rscd=attachment;+filename="wheel-ubuntu-24.04-arm.zip"&se=2025-09-17T14:06:38Z&sig=9WdKVVP5XzVJDtUr5O8HOXeKmjuyfuwf3VB2liOOOYY=&ske=2025-09-18T01:24:30Z&skoid=ca7593d4.2
  inflating: ffsim-0.0.60.dev0-cp39-abi3-manylinux_2_34_aarch64.whl
# pip install ./ffsim*
Processing ./ffsim-0.0.60.dev0-cp39-abi3-manylinux_2_34_aarch64.whl
Collecting jax (from ffsim==0.0.60.dev0)
  Downloading jax-0.7.2-py3-none-any.whl.metadata (13 kB)
Collecting numpy (from ffsim==0.0.60.dev0)
  Downloading numpy-2.3.3-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl.metadata (62 kB)
Collecting opt-einsum (from ffsim==0.0.60.dev0)
  Downloading opt_einsum-3.4.0-py3-none-any.whl.metadata (6.3 kB)
Collecting orjson (from ffsim==0.0.60.dev0)
  Downloading orjson-3.11.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl.metadata (41 kB)
Collecting pyscf>=2.9 (from ffsim==0.0.60.dev0)
  Downloading pyscf-2.10.0-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl.metadata (6.4 kB)
Collecting qiskit>=1.3 (from ffsim==0.0.60.dev0)
  Downloading qiskit-2.1.2-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl.metadata (12 kB)
Collecting scipy (from ffsim==0.0.60.dev0)
  Downloading scipy-1.16.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl.metadata (62 kB)
Collecting typing-extensions (from ffsim==0.0.60.dev0)
  Downloading typing_extensions-4.15.0-py3-none-any.whl.metadata (3.3 kB)
Collecting h5py>=2.7 (from pyscf>=2.9->ffsim==0.0.60.dev0)
  Downloading h5py-3.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl.metadata (2.7 kB)
Collecting setuptools (from pyscf>=2.9->ffsim==0.0.60.dev0)
  Downloading setuptools-80.9.0-py3-none-any.whl.metadata (6.6 kB)
Collecting rustworkx>=0.15.0 (from qiskit>=1.3->ffsim==0.0.60.dev0)
  Downloading rustworkx-0.17.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl.metadata (10 kB)
Collecting dill>=0.3 (from qiskit>=1.3->ffsim==0.0.60.dev0)
  Downloading dill-0.4.0-py3-none-any.whl.metadata (10 kB)
Collecting stevedore>=3.0.0 (from qiskit>=1.3->ffsim==0.0.60.dev0)
  Downloading stevedore-5.5.0-py3-none-any.whl.metadata (2.2 kB)
Collecting jaxlib<=0.7.2,>=0.7.2 (from jax->ffsim==0.0.60.dev0)
  Downloading jaxlib-0.7.2-cp313-cp313-manylinux_2_27_aarch64.whl.metadata (1.3 kB)
Collecting ml_dtypes>=0.5.0 (from jax->ffsim==0.0.60.dev0)
  Downloading ml_dtypes-0.5.3-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl.metadata (8.9 kB)
Downloading pyscf-2.10.0-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl (44.5 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 44.5/44.5 MB 24.7 MB/s  0:00:01
Downloading h5py-3.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (4.7 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 4.7/4.7 MB 18.4 MB/s  0:00:00
Downloading numpy-2.3.3-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl (14.3 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 14.3/14.3 MB 24.5 MB/s  0:00:00
Downloading qiskit-2.1.2-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl (7.4 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 7.4/7.4 MB 24.0 MB/s  0:00:00
Downloading dill-0.4.0-py3-none-any.whl (119 kB)
Downloading rustworkx-0.17.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (2.1 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.1/2.1 MB 25.2 MB/s  0:00:00
Downloading scipy-1.16.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl (33.3 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 33.3/33.3 MB 23.4 MB/s  0:00:01
Downloading stevedore-5.5.0-py3-none-any.whl (49 kB)
Downloading jax-0.7.2-py3-none-any.whl (2.8 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.8/2.8 MB 23.0 MB/s  0:00:00
Downloading jaxlib-0.7.2-cp313-cp313-manylinux_2_27_aarch64.whl (71.6 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 71.6/71.6 MB 9.8 MB/s  0:00:07
Downloading ml_dtypes-0.5.3-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl (5.0 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 5.0/5.0 MB 20.8 MB/s  0:00:00
Downloading opt_einsum-3.4.0-py3-none-any.whl (71 kB)
Downloading orjson-3.11.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (123 kB)
Downloading setuptools-80.9.0-py3-none-any.whl (1.2 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.2/1.2 MB 24.0 MB/s  0:00:00
Downloading typing_extensions-4.15.0-py3-none-any.whl (44 kB)
Installing collected packages: typing-extensions, stevedore, setuptools, orjson, opt-einsum, numpy, dill, scipy, rustworkx, ml_dtypes, h5py, qiskit, pyscf, jaxlib, jax, ffsim
Successfully installed dill-0.4.0 ffsim-0.0.60.dev0 h5py-3.14.0 jax-0.7.2 jaxlib-0.7.2 ml_dtypes-0.5.3 numpy-2.3.3 opt-einsum-3.4.0 orjson-3.11.3 pyscf-2.10.0 qiskit-2.1.2 rustworkx-0.17.1 scipy-1.16.2 setuptools-80.9.0 stevedore-5.5.0 typing-extensions-4.15.0
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.
#
```