### PR TITLE
Bug fix: Clamp `c` value in `ffim/qiskit/gates/orbital_rotation.py/`

### DIFF
--- a/python/ffsim/qiskit/gates/orbital_rotation.py
+++ b/python/ffsim/qiskit/gates/orbital_rotation.py
@@ -196,6 +196,11 @@ def _orbital_rotation_jw(
 ) -> Iterator[CircuitInstruction]:
     givens_rotations, phase_shifts = linalg.givens_decomposition(orbital_rotation)
     for c, s, i, j in givens_rotations:
+        c = float(c)
+        if c > 1.0:
+            c = 1.0
+        elif c < -1.0:
+            c = -1.0
         yield CircuitInstruction(
             XXPlusYYGate(2 * math.acos(c), cmath.phase(s) - 0.5 * math.pi),
             (qubits[i], qubits[j]),


### PR DESCRIPTION
Clamp the value of 'c' to the range [-1.0, 1.0] to prevent raising `math.acos(c)` math domain error from floating point errors causing `c` to be outside the range when decomposing `OrbitalRotationJW` gate.

- Closes issue https://github.com/qiskit-community/ffsim/issues/502
