### PR TITLE
change alpha-beta double-factorization convention by factor of 2

### DIFF
--- a/python/ffsim/linalg/double_factorized_decomposition.py
+++ b/python/ffsim/linalg/double_factorized_decomposition.py
@@ -869,7 +869,7 @@ def double_factorized_t2_alpha_beta(
                     orbital_rotation_a, orbital_rotation_b
                 )
             return (
-                2j
+                1j
                 * np.einsum(
                     "kpq,kap,kip,kbq,kjq->ijab",
                     expanded_diag_coulomb_mats,
@@ -1031,7 +1031,7 @@ def _double_factorized_t2_alpha_beta_compressed(
                     jax.scipy.linalg.block_diag(orbital_rotation_a, orbital_rotation_b)
                 )
             reconstructed = (
-                2j
+                1j
                 * contract(
                     "kpq,kap,kip,kbq,kjq->ijab",
                     expanded_diag_coulomb_mats,
@@ -1104,7 +1104,7 @@ def _double_factorized_t2_alpha_beta_explicit(
 
     eigs, orbital_rotations = np.linalg.eigh(one_body_tensors)
     eigs = np.concatenate([eigs[:, :, 0], eigs[:, :, 1]], axis=-1)
-    coeffs = 0.25 * np.array([1, -1, -1, 1]) * singular_vals[:, None]
+    coeffs = 0.5 * np.array([1, -1, -1, 1]) * singular_vals[:, None]
     big_diag_coulomb_mats = (
         coeffs[:, :, None, None] * eigs[:, :, :, None] * eigs[:, :, None, :]
     )

--- a/tests/python/linalg/double_factorized_decomposition_test.py
+++ b/tests/python/linalg/double_factorized_decomposition_test.py
@@ -60,7 +60,7 @@ def reconstruct_t2_alpha_beta(
             orbital_rotation_a, orbital_rotation_b
         )
     return (
-        2j
+        1j
         * contract(
             "kpq,kap,kip,kbq,kjq->ijab",
             expanded_diag_coulomb_mats,

--- a/tests/python/variational/ucj_spin_unbalanced_test.py
+++ b/tests/python/variational/ucj_spin_unbalanced_test.py
@@ -156,7 +156,7 @@ def test_t_amplitudes_energy():
     # Compute the energy ⟨ψ|H|ψ⟩ of the ansatz state
     linop = ffsim.linear_operator(mol_hamiltonian, norb=norb, nelec=nelec)
     energy = np.real(np.vdot(ansatz_state, linop @ ansatz_state))
-    np.testing.assert_allclose(energy, -15.125423)
+    np.testing.assert_allclose(energy, -15.128401)
 
     # Test setting number of reps as tuple
     n_reps = (4, 2)
@@ -167,7 +167,7 @@ def test_t_amplitudes_energy():
         reference_state, operator, norb=norb, nelec=nelec
     )
     energy = np.real(np.vdot(ansatz_state, linop @ ansatz_state))
-    np.testing.assert_allclose(energy, -15.125875)
+    np.testing.assert_allclose(energy, -15.128847)
 
     # Test setting number of reps as None
     operator = ffsim.UCJOpSpinUnbalanced.from_t_amplitudes(ccsd.t2, t1=ccsd.t1)
@@ -175,7 +175,7 @@ def test_t_amplitudes_energy():
         reference_state, operator, norb=norb, nelec=nelec
     )
     energy = np.real(np.vdot(ansatz_state, linop @ ansatz_state))
-    np.testing.assert_allclose(energy, -15.134145)
+    np.testing.assert_allclose(energy, -15.139681)
 
 
 def test_t_amplitudes_random_n_reps():


### PR DESCRIPTION
This factor matches the assumption used in `UCJOpSpinUnbalanced.from_t_amplitudes`, improving the energy of the ansatz state.