### PR TITLE
normal order: break out to outer loop

### DIFF
--- a/python/ffsim/_slow/fermion_operator.py
+++ b/python/ffsim/_slow/fermion_operator.py
@@ -254,6 +254,8 @@ def _normal_ordered_term(
                     # swap operators and update sign
                     term[j - 1], term[j] = term[j], term[j - 1]
                     parity = not parity
+            if zero:
+                break
         if zero:
             continue
         term = tuple(term)

--- a/src/fermion_operator.rs
+++ b/src/fermion_operator.rs
@@ -562,7 +562,7 @@ fn _normal_ordered_term(term: &[(bool, bool, i32)], coeff: &Complex64) -> Fermio
     while let Some((mut term, coeff)) = stack.pop() {
         let mut parity = false;
         let mut zero = false;
-        for i in 1..term.len() {
+        'outer: for i in 1..term.len() {
             // shift the operator at index i to the left until it's in the correct location
             for j in (1..=i).rev() {
                 let (action_right, spin_right, index_right) = term[j];
@@ -573,7 +573,7 @@ fn _normal_ordered_term(term: &[(bool, bool, i32)], coeff: &Complex64) -> Fermio
                         Ordering::Equal => {
                             // operators are the same, so product is zero
                             zero = true;
-                            break;
+                            break 'outer;
                         }
                         Ordering::Greater => {
                             // swap operators and update sign


### PR DESCRIPTION
#449 fixed a bug but introduced a performance regression because it only broke out of the inner loop when it should have broke out of the outer loop too.