### PR TITLE
fix: avoid math domain error in orbital rotation gates

### DIFF
--- a/python/ffsim/qiskit/gates/orbital_rotation.py
+++ b/python/ffsim/qiskit/gates/orbital_rotation.py
@@ -197,7 +197,7 @@ def _orbital_rotation_jw(
     givens_rotations, phase_shifts = linalg.givens_decomposition(orbital_rotation)
     for c, s, i, j in givens_rotations:
         yield CircuitInstruction(
-            XXPlusYYGate(2 * math.acos(c), cmath.phase(s) - 0.5 * math.pi),
+            XXPlusYYGate(2 * math.acos(max(-1.0, min(1.0, c))), cmath.phase(s) - 0.5 * math.pi),
             (qubits[i], qubits[j]),
         )
     for i, phase_shift in enumerate(phase_shifts):

--- a/python/ffsim/qiskit/gates/slater_determinant.py
+++ b/python/ffsim/qiskit/gates/slater_determinant.py
@@ -312,7 +312,7 @@ def _prepare_slater_determinant_jw(
     givens_rotations = _givens_decomposition_slater(orbital_coeffs)
     for c, s, i, j in givens_rotations:
         yield CircuitInstruction(
-            XXPlusYYGate(2 * math.acos(c), cmath.phase(s) - 0.5 * math.pi),
+            XXPlusYYGate(2 * math.acos(max(-1.0, min(1.0, c))), cmath.phase(s) - 0.5 * math.pi),
             (qubits[i], qubits[j]),
         )
 


### PR DESCRIPTION
## Problem
When decomposing gates using `givens_decomposition`, the calculated cosine `c` can sometimes fall slightly outside the `[-1.0, 1.0]` interval due to floating point precision errors. This causes `math.acos(c)` to raise a `ValueError: math domain error` when passing the argument to `XXPlusYYGate`.

## Solution  
Clamp the `c` argument between `-1.0` and `1.0` using `max(-1.0, min(1.0, c))` before calling `math.acos` in both `orbital_rotation.py` and `slater_determinant.py`.

## Testing
This resolves the intermittent `ValueError: math domain error` encountered when decomposing large, complex orbital rotations where floating point drift creates Givens coefficients slightly outside the domain limit.

Closes #502