### PR TITLE
Modified `givens_decomposition` logic for compact circuit compilation

### DIFF
--- a/python/ffsim/linalg/givens.py
+++ b/python/ffsim/linalg/givens.py
@@ -83,10 +83,10 @@ def zrotg(a: complex, b: complex, tol=1e-12) -> tuple[float, complex]:
     Note that in contrast to ``scipy.linalg.blas.zrotg``, this function returns c as a
     float rather than a complex.
     """
-    if cmath.isclose(b, 0.0, abs_tol=tol):
-        return 1.0, 0j
     if cmath.isclose(a, 0.0, abs_tol=tol):
         return 0.0, 1 + 0j
+    if cmath.isclose(b, 0.0, abs_tol=tol):
+        return 1.0, 0j
     c, s = zrotg_(a, b)
     return c.real, s
 

--- a/python/ffsim/linalg/givens.py
+++ b/python/ffsim/linalg/givens.py
@@ -83,10 +83,10 @@ def zrotg(a: complex, b: complex, tol=1e-12) -> tuple[float, complex]:
     Note that in contrast to ``scipy.linalg.blas.zrotg``, this function returns c as a
     float rather than a complex.
     """
-    if cmath.isclose(a, 0.0, abs_tol=tol):
-        return 0.0, 1 + 0j
     if cmath.isclose(b, 0.0, abs_tol=tol):
         return 1.0, 0j
+    if cmath.isclose(a, 0.0, abs_tol=tol):
+        return 0.0, 1 + 0j
     c, s = zrotg_(a, b)
     return c.real, s
 

--- a/src/linalg/givens.rs
+++ b/src/linalg/givens.rs
@@ -86,15 +86,13 @@ pub fn givens_decomposition(
             for j in 0..=i {
                 let target_index = i - j;
                 let row = n - j - 1;
-                if current_matrix[[row, target_index]] != Complex64::new(0.0, 0.0) {
+                if current_matrix[[row, target_index]].norm() > tol {
                     let (c, s) = zrotg_safe(
                         current_matrix[[row, target_index + 1]],
                         current_matrix[[row, target_index]],
                         tol,
                     );
-                    if (c - 1.0).abs() > tol {
-                        right_rotations.push((c, s, target_index + 1, target_index));
-                    }
+                    right_rotations.push((c, s, target_index + 1, target_index));
                     rotate_columns_in_place(
                         &mut current_matrix,
                         target_index + 1,
@@ -108,15 +106,13 @@ pub fn givens_decomposition(
             for j in 0..=i {
                 let target_index = n - i + j - 1;
                 let col = j;
-                if current_matrix[[target_index, col]] != Complex64::new(0.0, 0.0) {
+                if current_matrix[[target_index, col]].norm() > tol {
                     let (c, s) = zrotg_safe(
                         current_matrix[[target_index - 1, col]],
                         current_matrix[[target_index, col]],
                         tol,
                     );
-                    if (c - 1.0).abs() > tol {
-                        left_rotations.push((c, s, target_index - 1, target_index));
-                    }
+                    left_rotations.push((c, s, target_index - 1, target_index));
                     rotate_rows_in_place(&mut current_matrix, target_index - 1, target_index, c, s);
                 }
             }

--- a/src/linalg/givens.rs
+++ b/src/linalg/givens.rs
@@ -17,11 +17,11 @@ type GivensRotationTuple = (f64, Complex64, usize, usize);
 type GivensDecompositionResult = (Vec<GivensRotationTuple>, Py<PyArray1<Complex64>>);
 
 fn zrotg_safe(a: Complex64, b: Complex64, tol: f64) -> (f64, Complex64) {
-    if a.norm() <= tol {
-        return (0.0, Complex64::new(1.0, 0.0));
-    }
     if b.norm() <= tol {
         return (1.0, Complex64::new(0.0, 0.0));
+    }
+    if a.norm() <= tol {
+        return (0.0, Complex64::new(1.0, 0.0));
     }
     let abs_a = a.norm();
     let abs_b = b.norm();
@@ -92,7 +92,9 @@ pub fn givens_decomposition(
                         current_matrix[[row, target_index]],
                         tol,
                     );
-                    right_rotations.push((c, s, target_index + 1, target_index));
+                    if (c - 1.0).abs() > tol {
+                        right_rotations.push((c, s, target_index + 1, target_index));
+                    }
                     rotate_columns_in_place(
                         &mut current_matrix,
                         target_index + 1,
@@ -112,7 +114,9 @@ pub fn givens_decomposition(
                         current_matrix[[target_index, col]],
                         tol,
                     );
-                    left_rotations.push((c, s, target_index - 1, target_index));
+                    if (c - 1.0).abs() > tol {
+                        left_rotations.push((c, s, target_index - 1, target_index));
+                    }
                     rotate_rows_in_place(&mut current_matrix, target_index - 1, target_index, c, s);
                 }
             }

--- a/src/linalg/givens.rs
+++ b/src/linalg/givens.rs
@@ -17,11 +17,11 @@ type GivensRotationTuple = (f64, Complex64, usize, usize);
 type GivensDecompositionResult = (Vec<GivensRotationTuple>, Py<PyArray1<Complex64>>);
 
 fn zrotg_safe(a: Complex64, b: Complex64, tol: f64) -> (f64, Complex64) {
-    if a.norm() <= tol {
-        return (0.0, Complex64::new(1.0, 0.0));
-    }
     if b.norm() <= tol {
         return (1.0, Complex64::new(0.0, 0.0));
+    }
+    if a.norm() <= tol {
+        return (0.0, Complex64::new(1.0, 0.0));
     }
     let abs_a = a.norm();
     let abs_b = b.norm();

--- a/src/linalg/givens.rs
+++ b/src/linalg/givens.rs
@@ -92,9 +92,7 @@ pub fn givens_decomposition(
                         current_matrix[[row, target_index]],
                         tol,
                     );
-                    if (c - 1.0).abs() > tol {
-                        right_rotations.push((c, s, target_index + 1, target_index));
-                    }
+                    right_rotations.push((c, s, target_index + 1, target_index));
                     rotate_columns_in_place(
                         &mut current_matrix,
                         target_index + 1,
@@ -114,9 +112,7 @@ pub fn givens_decomposition(
                         current_matrix[[target_index, col]],
                         tol,
                     );
-                    if (c - 1.0).abs() > tol {
-                        left_rotations.push((c, s, target_index - 1, target_index));
-                    }
+                    left_rotations.push((c, s, target_index - 1, target_index));
                     rotate_rows_in_place(&mut current_matrix, target_index - 1, target_index, c, s);
                 }
             }

--- a/src/linalg/givens.rs
+++ b/src/linalg/givens.rs
@@ -17,11 +17,11 @@ type GivensRotationTuple = (f64, Complex64, usize, usize);
 type GivensDecompositionResult = (Vec<GivensRotationTuple>, Py<PyArray1<Complex64>>);
 
 fn zrotg_safe(a: Complex64, b: Complex64, tol: f64) -> (f64, Complex64) {
-    if b.norm() <= tol {
-        return (1.0, Complex64::new(0.0, 0.0));
-    }
     if a.norm() <= tol {
         return (0.0, Complex64::new(1.0, 0.0));
+    }
+    if b.norm() <= tol {
+        return (1.0, Complex64::new(0.0, 0.0));
     }
     let abs_a = a.norm();
     let abs_b = b.norm();
@@ -92,7 +92,9 @@ pub fn givens_decomposition(
                         current_matrix[[row, target_index]],
                         tol,
                     );
-                    right_rotations.push((c, s, target_index + 1, target_index));
+                    if (c - 1.0).abs() > tol {
+                        right_rotations.push((c, s, target_index + 1, target_index));
+                    }
                     rotate_columns_in_place(
                         &mut current_matrix,
                         target_index + 1,
@@ -112,7 +114,9 @@ pub fn givens_decomposition(
                         current_matrix[[target_index, col]],
                         tol,
                     );
-                    left_rotations.push((c, s, target_index - 1, target_index));
+                    if (c - 1.0).abs() > tol {
+                        left_rotations.push((c, s, target_index - 1, target_index));
+                    }
                     rotate_rows_in_place(&mut current_matrix, target_index - 1, target_index, c, s);
                 }
             }

--- a/src/linalg/givens.rs
+++ b/src/linalg/givens.rs
@@ -17,11 +17,11 @@ type GivensRotationTuple = (f64, Complex64, usize, usize);
 type GivensDecompositionResult = (Vec<GivensRotationTuple>, Py<PyArray1<Complex64>>);
 
 fn zrotg_safe(a: Complex64, b: Complex64, tol: f64) -> (f64, Complex64) {
-    if b.norm() <= tol {
-        return (1.0, Complex64::new(0.0, 0.0));
-    }
     if a.norm() <= tol {
         return (0.0, Complex64::new(1.0, 0.0));
+    }
+    if b.norm() <= tol {
+        return (1.0, Complex64::new(0.0, 0.0));
     }
     let abs_a = a.norm();
     let abs_b = b.norm();

--- a/tests/python/linalg/givens_test.py
+++ b/tests/python/linalg/givens_test.py
@@ -23,6 +23,22 @@ import ffsim
 from ffsim.linalg import givens_decomposition
 
 
+def reconstruct_orbital_rotation(
+    dim: int,
+    givens_rotations: list[tuple[float, complex, int, int]],
+    phase_shifts: np.ndarray,
+) -> np.ndarray:
+    """Reconstruct matrix from Givens decomposition."""
+    reconstructed = np.eye(dim, dtype=complex)
+    for i, phase_shift in enumerate(phase_shifts):
+        reconstructed[i] *= phase_shift
+    for c, s, i, j in givens_rotations[::-1]:
+        reconstructed[:, j], reconstructed[:, i] = zrot(
+            reconstructed[:, j], reconstructed[:, i], c, s.conjugate()
+        )
+    return reconstructed
+
+
 @pytest.mark.parametrize("dim", range(6))
 def test_givens_decomposition_definition(dim: int):
     """Test Givens decomposition definition."""
@@ -49,13 +65,9 @@ def test_givens_decomposition_reconstruct(dim: int):
     for _ in range(3):
         mat = ffsim.random.random_unitary(dim, seed=rng)
         givens_rotations, phase_shifts = givens_decomposition(mat)
-        reconstructed = np.eye(dim, dtype=complex)
-        for i, phase_shift in enumerate(phase_shifts):
-            reconstructed[i] *= phase_shift
-        for c, s, i, j in givens_rotations[::-1]:
-            reconstructed[:, j], reconstructed[:, i] = zrot(
-                reconstructed[:, j], reconstructed[:, i], c, s.conjugate()
-            )
+        reconstructed = reconstruct_orbital_rotation(
+            dim=dim, givens_rotations=givens_rotations, phase_shifts=phase_shifts
+        )
         np.testing.assert_allclose(reconstructed, mat)
 
 
@@ -63,18 +75,25 @@ def test_givens_decomposition_reconstruct(dim: int):
 def test_givens_decomposition_near_identity(dim: int):
     """Test Givens decomposition of a quasi-identity matrix."""
     rng = np.random.default_rng()
-    worst_case_lengths = (0, 0, 1, 3, 6, 10)
+    # Worst case: one elimination per subdiagonal entry of the unitary
+    worst_case_length = (dim * (dim - 1)) // 2
+    tol = 1e-12
+    dts = [1e-1, 1e-3, 1e-6, 1e-9]
 
-    for _ in range(3):
-        dt = tol = 10 ** rng.uniform(-8, -3)
+    for dt in dts:
         generator = ffsim.random.random_hermitian(dim, seed=rng)
         mat = expm(-1j * dt * generator)
-        givens_rotations, _ = givens_decomposition(mat, tol=tol)
+        givens_rotations, phase_shifts = givens_decomposition(mat, tol=tol)
 
-        assert len(givens_rotations) <= worst_case_lengths[dim], (
+        assert len(givens_rotations) <= worst_case_length, (
             f"dim={dim}, dt={dt:.3e}, got {len(givens_rotations)} rotations, "
-            f"expected at most {worst_case_lengths[dim]}"
+            f"expected at most {worst_case_length}"
         )
+
+        reconstructed = reconstruct_orbital_rotation(
+            dim=dim, givens_rotations=givens_rotations, phase_shifts=phase_shifts
+        )
+        np.testing.assert_allclose(reconstructed, mat, atol=tol)
 
 
 @pytest.mark.parametrize("dim", range(6))

--- a/tests/python/linalg/givens_test.py
+++ b/tests/python/linalg/givens_test.py
@@ -58,23 +58,6 @@ def test_givens_decomposition_reconstruct(dim: int):
             )
         np.testing.assert_allclose(reconstructed, mat)
 
-@pytest.mark.parametrize("dim", range(6))
-def test_givens_decomposition_near_identity(dim: int):
-    """Test Givens decomposition of a quasi-identity matrix."""
-    rng = np.random.default_rng()
-    worst_case_lengths = (0, 0, 1, 3, 6, 10)
-
-    for _ in range(3):
-        dt = tol = 10 ** rng.uniform(-8, -3)
-        generator = ffsim.random.random_hermitian(dim, seed=rng)
-        mat = expm(-1j * dt * generator)
-        givens_rotations, _ = givens_decomposition(mat, tol=tol)
-
-        assert len(givens_rotations) <= worst_case_lengths[dim], (
-            f"dim={dim}, dt={dt:.3e}, got {len(givens_rotations)} rotations, "
-            f"expected at most {worst_case_lengths[dim]}"
-        )
-
 
 @pytest.mark.parametrize("dim", range(6))
 def test_givens_decomposition_identity(dim: int):

--- a/tests/python/linalg/givens_test.py
+++ b/tests/python/linalg/givens_test.py
@@ -76,7 +76,7 @@ def test_givens_decomposition_near_identity(dim: int):
     """Test Givens decomposition of a quasi-identity matrix."""
     rng = np.random.default_rng()
     # Worst case: one elimination per subdiagonal entry of the unitary
-    worst_case_length = (dim * (dim - 1)) // 2
+    worst_case_length = dim * (dim - 1) // 2
     tol = 1e-12
     dts = [1e-1, 1e-3, 1e-6, 1e-9]
 

--- a/tests/python/linalg/givens_test.py
+++ b/tests/python/linalg/givens_test.py
@@ -77,18 +77,19 @@ def test_givens_decomposition_near_identity(dim: int):
     rng = np.random.default_rng()
     # Worst case: one elimination per subdiagonal entry of the unitary
     worst_case_length = dim * (dim - 1) // 2
-    tol = 1e-12
     dts = [1e-1, 1e-3, 1e-6, 1e-9]
 
     for dt in dts:
+        tol = 10 * dt
         generator = ffsim.random.random_hermitian(dim, seed=rng)
         mat = expm(-1j * dt * generator)
         givens_rotations, phase_shifts = givens_decomposition(mat, tol=tol)
 
-        assert len(givens_rotations) <= worst_case_length, (
-            f"dim={dim}, dt={dt:.3e}, got {len(givens_rotations)} rotations, "
-            f"expected at most {worst_case_length}"
-        )
+        if givens_rotations:
+            assert len(givens_rotations) < worst_case_length, (
+                f"dim={dim}, dt={dt:.3e}, got {len(givens_rotations)} rotations, "
+                f"expected at most {worst_case_length}"
+            )
 
         reconstructed = reconstruct_orbital_rotation(
             dim=dim, givens_rotations=givens_rotations, phase_shifts=phase_shifts

--- a/tests/python/linalg/givens_test.py
+++ b/tests/python/linalg/givens_test.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+from scipy.linalg import expm
 from scipy.linalg.lapack import zrot
 
 import ffsim
@@ -56,6 +57,23 @@ def test_givens_decomposition_reconstruct(dim: int):
                 reconstructed[:, j], reconstructed[:, i], c, s.conjugate()
             )
         np.testing.assert_allclose(reconstructed, mat)
+
+@pytest.mark.parametrize("dim", range(6))
+def test_givens_decomposition_near_identity(dim: int):
+    """Test Givens decomposition of a quasi-identity matrix."""
+    rng = np.random.default_rng()
+    worst_case_lengths = (0, 0, 1, 3, 6, 10)
+
+    for _ in range(3):
+        dt = tol = 10 ** rng.uniform(-8, -3)
+        generator = ffsim.random.random_hermitian(dim, seed=rng)
+        mat = expm(-1j * dt * generator)
+        givens_rotations, _ = givens_decomposition(mat, tol=tol)
+
+        assert len(givens_rotations) <= worst_case_lengths[dim], (
+            f"dim={dim}, dt={dt:.3e}, got {len(givens_rotations)} rotations, "
+            f"expected at most {worst_case_lengths[dim]}"
+        )
 
 
 @pytest.mark.parametrize("dim", range(6))

--- a/tests/python/linalg/givens_test.py
+++ b/tests/python/linalg/givens_test.py
@@ -28,7 +28,7 @@ def reconstruct_orbital_rotation(
     givens_rotations: list[tuple[float, complex, int, int]],
     phase_shifts: np.ndarray,
 ) -> np.ndarray:
-    """Reconstruct matrix from Givens decomposition."""
+    """Reconstruct orbital rotation from Givens decomposition."""
     reconstructed = np.eye(dim, dtype=complex)
     for i, phase_shift in enumerate(phase_shifts):
         reconstructed[i] *= phase_shift
@@ -72,29 +72,22 @@ def test_givens_decomposition_reconstruct(dim: int):
 
 
 @pytest.mark.parametrize("dim", range(6))
-def test_givens_decomposition_near_identity(dim: int):
-    """Test Givens decomposition of a quasi-identity matrix."""
+@pytest.mark.parametrize("scale", [1e-3, 1e-6, 1e-9, 1e-12, 1e-15])
+def test_givens_decomposition_near_identity(dim: int, scale: float):
+    """Test Givens decomposition of a near-identity orbital rotation."""
     rng = np.random.default_rng()
     # Worst case: one elimination per subdiagonal entry of the unitary
     worst_case_length = dim * (dim - 1) // 2
-    dts = [1e-1, 1e-3, 1e-6, 1e-9]
-
-    for dt in dts:
-        tol = 10 * dt
-        generator = ffsim.random.random_hermitian(dim, seed=rng)
-        mat = expm(-1j * dt * generator)
-        givens_rotations, phase_shifts = givens_decomposition(mat, tol=tol)
-
-        if givens_rotations:
-            assert len(givens_rotations) < worst_case_length, (
-                f"dim={dim}, dt={dt:.3e}, got {len(givens_rotations)} rotations, "
-                f"expected at most {worst_case_length}"
-            )
-
-        reconstructed = reconstruct_orbital_rotation(
-            dim=dim, givens_rotations=givens_rotations, phase_shifts=phase_shifts
-        )
-        np.testing.assert_allclose(reconstructed, mat, atol=tol)
+    generator = 1j * scale * ffsim.random.random_hermitian(dim, seed=rng)
+    orbital_rotation = expm(generator)
+    tol = 10 * scale
+    givens_rotations, phase_shifts = givens_decomposition(orbital_rotation, tol=tol)
+    if dim > 1:
+        assert len(givens_rotations) < worst_case_length
+    reconstructed = reconstruct_orbital_rotation(
+        dim=dim, givens_rotations=givens_rotations, phase_shifts=phase_shifts
+    )
+    np.testing.assert_allclose(reconstructed, orbital_rotation, atol=tol)
 
 
 @pytest.mark.parametrize("dim", range(6))

--- a/tests/python/linalg/givens_test.py
+++ b/tests/python/linalg/givens_test.py
@@ -60,6 +60,24 @@ def test_givens_decomposition_reconstruct(dim: int):
 
 
 @pytest.mark.parametrize("dim", range(6))
+def test_givens_decomposition_near_identity(dim: int):
+    """Test Givens decomposition of a quasi-identity matrix."""
+    rng = np.random.default_rng()
+    worst_case_lengths = (0, 0, 1, 3, 6, 10)
+
+    for _ in range(3):
+        dt = tol = 10 ** rng.uniform(-8, -3)
+        generator = ffsim.random.random_hermitian(dim, seed=rng)
+        mat = expm(-1j * dt * generator)
+        givens_rotations, _ = givens_decomposition(mat, tol=tol)
+
+        assert len(givens_rotations) <= worst_case_lengths[dim], (
+            f"dim={dim}, dt={dt:.3e}, got {len(givens_rotations)} rotations, "
+            f"expected at most {worst_case_lengths[dim]}"
+        )
+
+
+@pytest.mark.parametrize("dim", range(6))
 def test_givens_decomposition_identity(dim: int):
     """Test Givens decomposition on identity matrix."""
     mat = np.eye(dim)


### PR DESCRIPTION
This PR corrects the logic of the `zrotg_safe` function, handling the case where both matrix elements `a` and `b` are close to `0` and therefore return an identity gate. This results in more efficient compilation for circuits close to the identity (as Trotter steps for a small time interval) by eliminating unnecessary SWAP operations. To test this case, a new function called `test_givens_decomposition_near_identity` has been added.