### PR TITLE
fix layer indexing bug in GivensAnsatzOp

### DIFF
--- a/python/ffsim/variational/givens.py
+++ b/python/ffsim/variational/givens.py
@@ -257,7 +257,15 @@ def _brickwork_givens_rotations(
         if i % 2 == 0:
             # Even layer
             # Get the index of the even layer this Givens rotation should go in
-            index = max(odd_layer_index[i], odd_layer_index[j]) + 1
+            index = (
+                max(
+                    even_layer_index[i],
+                    even_layer_index[j],
+                    odd_layer_index[i],
+                    odd_layer_index[j],
+                )
+                + 1
+            )
             # Add the Givens rotation in the appropriate place
             even_layers[index][i // 2] = ((i, j), theta, phi)
             # Update the even layer index
@@ -266,7 +274,12 @@ def _brickwork_givens_rotations(
         else:
             # Odd layer
             # Get the index of the odd layer this Givens rotation should go in
-            index = max(even_layer_index[i], even_layer_index[j])
+            index = max(
+                odd_layer_index[i] + 1,
+                odd_layer_index[j] + 1,
+                even_layer_index[i],
+                even_layer_index[j],
+            )
             # Add the Givens rotation in the appropriate place
             odd_layers[index][i // 2] = ((i, j), theta, phi)
             # Update the odd layer index

--- a/tests/python/variational/givens_test.py
+++ b/tests/python/variational/givens_test.py
@@ -213,6 +213,22 @@ def test_givens_orbital_rotation_t_amplitudes():
     np.testing.assert_allclose(actual, expected)
 
 
+def test_givens_orbital_rotation_sparse_roundtrip():
+    """Test round-tripping a sparse orbital rotation."""
+    orbital_rotation = np.array(
+        [
+            [1, 0, 0, 0],
+            [0, 0, 1, 0],
+            [0, 0, 0, 1],
+            [0, 1, 0, 0],
+        ],
+        dtype=complex,
+    )
+    operator = ffsim.GivensAnsatzOp.from_orbital_rotation(orbital_rotation)
+    roundtripped = operator.to_orbital_rotation()
+    np.testing.assert_allclose(roundtripped, orbital_rotation, atol=1e-12)
+
+
 def test_givens_orbital_rotation_fully_parameterized():
     """Test initialization from orbital rotation gives fully parametrized ansatz."""
     norb = 8


### PR DESCRIPTION
The computation of the layer index didn't account for layers being skipped.