### PR TITLE
Swap the order of the `a` and `b` checks in `zrotg_safe`

### DIFF
--- a/python/ffsim/linalg/givens.py
+++ b/python/ffsim/linalg/givens.py
@@ -83,10 +83,10 @@ def zrotg(a: complex, b: complex, tol=1e-12) -> tuple[float, complex]:
     Note that in contrast to ``scipy.linalg.blas.zrotg``, this function returns c as a
     float rather than a complex.
     """
-    if cmath.isclose(a, 0.0, abs_tol=tol):
-        return 0.0, 1 + 0j
     if cmath.isclose(b, 0.0, abs_tol=tol):
         return 1.0, 0j
+    if cmath.isclose(a, 0.0, abs_tol=tol):
+        return 0.0, 1 + 0j
     c, s = zrotg_(a, b)
     return c.real, s
 

--- a/src/linalg/givens.rs
+++ b/src/linalg/givens.rs
@@ -17,11 +17,11 @@ type GivensRotationTuple = (f64, Complex64, usize, usize);
 type GivensDecompositionResult = (Vec<GivensRotationTuple>, Py<PyArray1<Complex64>>);
 
 fn zrotg_safe(a: Complex64, b: Complex64, tol: f64) -> (f64, Complex64) {
-    if a.norm() <= tol {
-        return (0.0, Complex64::new(1.0, 0.0));
-    }
     if b.norm() <= tol {
         return (1.0, Complex64::new(0.0, 0.0));
+    }
+    if a.norm() <= tol {
+        return (0.0, Complex64::new(1.0, 0.0));
     }
     let abs_a = a.norm();
     let abs_b = b.norm();

--- a/tests/python/linalg/givens_test.py
+++ b/tests/python/linalg/givens_test.py
@@ -17,7 +17,6 @@ from pathlib import Path
 import numpy as np
 import pytest
 from scipy.linalg.lapack import zrot
-from scipy.linalg import expm
 
 import ffsim
 from ffsim.linalg import givens_decomposition

--- a/tests/python/linalg/givens_test.py
+++ b/tests/python/linalg/givens_test.py
@@ -17,6 +17,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 from scipy.linalg.lapack import zrot
+from scipy.linalg import expm
 
 import ffsim
 from ffsim.linalg import givens_decomposition


### PR DESCRIPTION
Splits #644: with reference to that PR, this PR just swaps the order of the `a` and `b` checks in `zrotg_safe`; no test is implemented as the `push` logic in `zrotg_safe` is still independent of whether a certain Givens rotation happens to be the identity.