### PR TITLE
Gate Optimization in DiagCoulombEvolutionJW

### DIFF
--- a/python/ffsim/qiskit/gates/diag_coulomb.py
+++ b/python/ffsim/qiskit/gates/diag_coulomb.py
@@ -190,39 +190,69 @@ def _diag_coulomb_evo_num_rep_jw(
     else:
         mat_aa, mat_ab, mat_bb = mat
 
-    # gates that involve a single spin sector
+    z_coeffs = np.zeros(2 * norb)
+
+    # Accumulate coefficients for gates that involve a single spin sector
     for sigma, this_mat in enumerate([mat_aa, mat_bb]):
         if this_mat is not None:
             for i in range(norb):
                 if this_mat[i, i]:
-                    yield CircuitInstruction(
-                        PhaseGate(-0.5 * this_mat[i, i] * time),
-                        (qubits[i + sigma * norb],),
-                    )
+                    z_coeffs[i + sigma * norb] += 0.5 * time * this_mat[i, i] * 0.5
+            for i, j in _iter_pairs(norb):
+                if this_mat[i, j]:
+                    coef = time * this_mat[i, j] / 4.0
+                    z_coeffs[i + sigma * norb] += coef
+                    z_coeffs[j + sigma * norb] += coef
+
+    # Accumulate coefficients for gates that involve both spin sectors
+    if mat_ab is not None:
+        for i in range(norb):
+            if mat_ab[i, i]:
+                coef = time * mat_ab[i, i] / 4.0
+                z_coeffs[i] += coef
+                z_coeffs[i + norb] += coef
+        for i, j in _iter_pairs(norb):
+            if mat_ab[i, j]:
+                coef = time * mat_ab[i, j] / 4.0
+                z_coeffs[i] += coef
+                z_coeffs[j + norb] += coef
+            if mat_ab[j, i]:
+                coef = time * mat_ab[j, i] / 4.0
+                z_coeffs[j] += coef
+                z_coeffs[i + norb] += coef
+
+    # Yield all aggregated PhaseGates first
+    for i in range(2 * norb):
+        if z_coeffs[i] != 0:
+            yield CircuitInstruction(PhaseGate(-2 * z_coeffs[i]), (qubits[i],))
+
+    # Yield all RZZGates for a single spin sector
+    for sigma, this_mat in enumerate([mat_aa, mat_bb]):
+        if this_mat is not None:
             for i, j in _iter_pairs(norb):
                 if this_mat[i, j]:
                     yield CircuitInstruction(
-                        CPhaseGate(-this_mat[i, j] * time),
+                        RZZGate(0.5 * time * this_mat[i, j]),
                         (qubits[i + sigma * norb], qubits[j + sigma * norb]),
                     )
 
-    # gates that involve both spin sectors
+    # Yield all RZZGates that involve both spin sectors
     if mat_ab is not None:
         for i in range(norb):
             if mat_ab[i, i]:
                 yield CircuitInstruction(
-                    CPhaseGate(-mat_ab[i, i] * time),
+                    RZZGate(0.5 * time * mat_ab[i, i]),
                     (qubits[i], qubits[i + norb]),
                 )
         for i, j in _iter_pairs(norb):
             if mat_ab[i, j]:
                 yield CircuitInstruction(
-                    CPhaseGate(-mat_ab[i, j] * time),
+                    RZZGate(0.5 * time * mat_ab[i, j]),
                     (qubits[i], qubits[j + norb]),
                 )
             if mat_ab[j, i]:
                 yield CircuitInstruction(
-                    CPhaseGate(-mat_ab[j, i] * time),
+                    RZZGate(0.5 * time * mat_ab[j, i]),
                     (qubits[j], qubits[i + norb]),
                 )
 


### PR DESCRIPTION
Changed the gate decomposition in the number operator representation (`_diag_coulomb_evo_num_rep_jw`). Right now it yields PhaseGates and CPhaseGates for every diagonal Coulomb term. This new approach accumulates all single-qubit Z-rotations into a coefficient array (`z_coeffs`), applies them all at the start using a single PhaseGate per qubit, and then uses RZZGates for the two-qubit interaction terms.

By the Jordan-Wigner mapping for number operators, $n_p = \frac{I-Z_p}{2}$ and the interaction term $n_p n_q$ expands to $\frac{I - Z_p - Z_q + Z_p Z_q}{4}$. So for single-qubit Z terms, each term $Z_{pq} n_p n_q$ contributes a factor of $\frac{t Z_{pq}}{4}$ to the $Z_p$ and $Z_q$ phases. These are accumulated via `coef = time * this_mat[i, j] / 4.0`. And for two-qubit ZZ terms, each term contributes $\exp\left(-i \frac{t Z_{pq}}{4} Z_p Z_q\right)$, which is equivalent to `RZZGate(0.5 * time * Z_pq)`.

For a 50-orbital system with 100 trials:

| | Avg. CX count | Avg. RZ count | Avg. depth
| -- | -- | -- | -- |
| **Current** | 4883.04 | 4883.04 | 1541.07 |
| **New** | 4842.04 | 4842.04 | 1414.03 |

Transpilation speedup: 24.9% (MacBook Pro M1)